### PR TITLE
fix: parse date-only strings as local time instead of UTC

### DIFF
--- a/src/utils/calendarRepository.ts
+++ b/src/utils/calendarRepository.ts
@@ -29,7 +29,11 @@ const formatDateOnly = (date: Date): string => {
 };
 
 const parseDateInput = (value: string): Date | undefined => {
-  const normalized = value.includes(' ') ? value.replace(' ', 'T') : value;
+  const normalized = value.includes(' ')
+    ? value.replace(' ', 'T')
+    : /^\d{4}-\d{2}-\d{2}$/.test(value)
+      ? `${value}T00:00:00`
+      : value;
   const parsed = new Date(normalized);
   return Number.isNaN(parsed.getTime()) ? undefined : parsed;
 };


### PR DESCRIPTION
## Problem
Date-only inputs (e.g. `2026-02-11`) passed to `parseDateInput` were parsed as UTC midnight by the `Date` constructor. In timezones behind UTC, this caused the resulting `Date` object to fall on the previous day in local time, leading to an off-by-one error when deriving the 14-day default range in `findEvents`.

## Fix
Append `T00:00:00` to date-only strings (`YYYY-MM-DD` format) before passing them to `new Date()`, so they are interpreted as local midnight rather than UTC midnight.

## Verification
All 499 tests pass (`pnpm test`), including the two previously failing cases in `calendarRepository.test.ts`.

---
[Warp conversation](https://app.warp.dev/conversation/3f1b8654-f37a-4c1a-a25e-12f011071cc8)

Co-Authored-By: Oz <oz-agent@warp.dev>