### PR TITLE
fix(reminders): handle cross-list moves via AppleScript when EventKit returns -3002

### DIFF
--- a/src/swift/EventKitCLI.crossListMove.test.ts
+++ b/src/swift/EventKitCLI.crossListMove.test.ts
@@ -1,0 +1,56 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const swiftPath = path.resolve(process.cwd(), 'src/swift/EventKitCLI.swift');
+const swiftSource = readFileSync(swiftPath, 'utf8');
+
+describe('EventKitCLI cross-list move fallback', () => {
+  it('exposes a moveReminderAcrossLists helper', () => {
+    expect(swiftSource).toMatch(
+      /private func moveReminderAcrossLists\(_ reminder: EKReminder, toListNamed targetListName: String\) throws -> ReminderJSON/,
+    );
+  });
+
+  it('tries EventKit reassignment before falling back', () => {
+    expect(swiftSource).toMatch(
+      /reminder\.calendar = targetList\s+do \{\s+try eventStore\.save\(reminder, commit: true\)/,
+    );
+  });
+
+  it('falls back to AppleScript move on save error', () => {
+    expect(swiftSource).toMatch(
+      /try runAppleScriptMove\(reminderUUID: originalUUID, toListNamed: targetListName\)/,
+    );
+  });
+
+  it('invokes osascript via Process for the AppleScript fallback', () => {
+    expect(swiftSource).toMatch(
+      /process\.launchPath = "\/usr\/bin\/osascript"/,
+    );
+    expect(swiftSource).toMatch(/move src to list/);
+  });
+
+  it('escapes backslashes and quotes in the target list name', () => {
+    expect(swiftSource).toMatch(
+      /replacingOccurrences\(of: "\\\\", with: "\\\\\\\\"\)\.replacingOccurrences\(of: "\\"", with: "\\\\\\""\)/,
+    );
+  });
+
+  it('re-fetches the moved reminder by title and creationDate', () => {
+    expect(swiftSource).toMatch(
+      /private func findReminderInList\(_ list: EKCalendar, matchingTitle title: String, creationDate: Date\?\) -> EKReminder\?/,
+    );
+  });
+
+  it('validates target list exists upfront to preserve update atomicity', () => {
+    expect(swiftSource).toMatch(
+      /\/\/ Validate target list exists upfront so a bad list name doesn't cause a[\s\S]*?if let targetListName = listName, targetListName != reminder\.calendar\.title \{\s+_ = try findList\(named: targetListName\)/,
+    );
+  });
+
+  it('triggers the move path only when target list differs from current', () => {
+    expect(swiftSource).toMatch(
+      /if let targetListName = listName, targetListName != reminder\.calendar\.title \{\s+return try moveReminderAcrossLists\(reminder, toListNamed: targetListName\)/,
+    );
+  });
+});

--- a/src/swift/EventKitCLI.crossListMove.test.ts
+++ b/src/swift/EventKitCLI.crossListMove.test.ts
@@ -5,29 +5,35 @@ const swiftPath = path.resolve(process.cwd(), 'src/swift/EventKitCLI.swift');
 const swiftSource = readFileSync(swiftPath, 'utf8');
 
 describe('EventKitCLI cross-list move fallback', () => {
-  it('exposes a moveReminderAcrossLists helper', () => {
+  it('exposes a moveReminderAcrossLists helper that returns the moved EKReminder', () => {
     expect(swiftSource).toMatch(
-      /private func moveReminderAcrossLists\(_ reminder: EKReminder, toListNamed targetListName: String\) throws -> ReminderJSON/,
+      /private func moveReminderAcrossLists\(_ reminder: EKReminder, toListNamed targetListName: String\) throws -> EKReminder/,
     );
   });
 
   it('tries EventKit reassignment before falling back', () => {
     expect(swiftSource).toMatch(
-      /reminder\.calendar = targetList\s+do \{\s+try eventStore\.save\(reminder, commit: true\)/,
+      /reminder\.calendar = targetList\s+do \{\s+try eventStore\.save\(reminder, commit: true\)\s+return reminder/,
     );
   });
 
   it('falls back to AppleScript move on save error', () => {
     expect(swiftSource).toMatch(
-      /try runAppleScriptMove\(reminderUUID: originalUUID, toListNamed: targetListName\)/,
+      /try runAppleScriptMove\(reminderUUID: originalUUID, toListNamed: targetList\.title\)/,
     );
   });
 
-  it('invokes osascript via Process for the AppleScript fallback', () => {
+  it('invokes osascript via Process using executableURL (non-deprecated API)', () => {
     expect(swiftSource).toMatch(
-      /process\.launchPath = "\/usr\/bin\/osascript"/,
+      /process\.executableURL = URL\(fileURLWithPath: "\/usr\/bin\/osascript"\)/,
     );
     expect(swiftSource).toMatch(/move src to list/);
+  });
+
+  it('discards AppleScript stdout via FileHandle.nullDevice to avoid pipe-buffer deadlock', () => {
+    expect(swiftSource).toMatch(
+      /process\.standardOutput = FileHandle\.nullDevice/,
+    );
   });
 
   it('escapes backslashes and quotes in the target list name', () => {
@@ -42,15 +48,21 @@ describe('EventKitCLI cross-list move fallback', () => {
     );
   });
 
-  it('validates target list exists upfront to preserve update atomicity', () => {
-    expect(swiftSource).toMatch(
-      /\/\/ Validate target list exists upfront so a bad list name doesn't cause a[\s\S]*?if let targetListName = listName, targetListName != reminder\.calendar\.title \{\s+_ = try findList\(named: targetListName\)/,
+  it('performs the move before any field mutations to keep the update atomic', () => {
+    // The move must resolve before any `reminder.title =`, `reminder.notes =`, etc.
+    const moveIndex = swiftSource.indexOf(
+      'let reminder = needsMove ? try moveReminderAcrossLists',
     );
+    const firstFieldMutationIndex = swiftSource.indexOf(
+      'if let newTitle = newTitle { reminder.title = newTitle }',
+    );
+    expect(moveIndex).toBeGreaterThan(-1);
+    expect(firstFieldMutationIndex).toBeGreaterThan(moveIndex);
   });
 
-  it('triggers the move path only when target list differs from current', () => {
+  it('treats empty or whitespace-only targetList as a no-op instead of routing through the default list', () => {
     expect(swiftSource).toMatch(
-      /if let targetListName = listName, targetListName != reminder\.calendar\.title \{\s+return try moveReminderAcrossLists\(reminder, toListNamed: targetListName\)/,
+      /let trimmedListName = listName\?\.trimmingCharacters\(in: \.whitespacesAndNewlines\)\s+let needsMove = trimmedListName\.map \{ !\$0\.isEmpty && \$0 != original\.calendar\.title \} \?\? false/,
     );
   });
 });

--- a/src/swift/EventKitCLI.swift
+++ b/src/swift/EventKitCLI.swift
@@ -747,12 +747,21 @@ class RemindersManager {
     }
 
     func updateReminder(id: String, newTitle: String?, listName: String?, notes: String?, location: String?, urlString: String?, isCompleted: Bool?, completionDateString: String?, startDateString: String?, dueDateString: String?, priority: Int?, alarmsJSON: String?, clearAlarms: Bool?, recurrenceRulesJSON: String?, clearRecurrence: Bool?, locationTriggerJSON: String?, clearLocationTrigger: Bool?) throws -> ReminderJSON {
-        guard let reminder = findReminder(withId: id) else { throw NSError(domain: "", code: 404, userInfo: [NSLocalizedDescriptionKey: "ID '\(id)' not found."]) }
-        // Validate target list exists upfront so a bad list name doesn't cause a
-        // partial update where other fields commit before the move error surfaces.
-        if let targetListName = listName, targetListName != reminder.calendar.title {
-            _ = try findList(named: targetListName)
-        }
+        guard let original = findReminder(withId: id) else { throw NSError(domain: "", code: 404, userInfo: [NSLocalizedDescriptionKey: "ID '\(id)' not found."]) }
+
+        // Perform cross-list move first, before any field mutations. Fast path uses
+        // EventKit direct reassignment; on save failure (e.g., com.apple.reminderkit
+        // error -3002 on cross-source moves) we fall back to AppleScript's `move`,
+        // which internally copy-and-deletes while preserving all metadata including
+        // creationDate. If the move throws, no field updates are attempted, so the
+        // overall update stays atomic: either the reminder ends up in the target
+        // list with the requested field changes, or nothing changes at all.
+        // Empty/whitespace targetList is treated as no-op to avoid routing through
+        // findList's default-list fallback when the caller did not intend a move.
+        let trimmedListName = listName?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let needsMove = trimmedListName.map { !$0.isEmpty && $0 != original.calendar.title } ?? false
+        let reminder = needsMove ? try moveReminderAcrossLists(original, toListNamed: trimmedListName!) : original
+
         if let newTitle = newTitle { reminder.title = newTitle }
         if let location = location {
             reminder.location = location.isEmpty ? nil : location
@@ -881,25 +890,16 @@ class RemindersManager {
         }
 
         try eventStore.save(reminder, commit: true)
-
-        // Handle cross-list move separately. EventKit cannot reassign `calendar`
-        // on a saved reminder across sources (raises com.apple.reminderkit error
-        // -3002), so we fall back to AppleScript's `move` command which preserves
-        // all metadata including creationDate. See moveReminderAcrossLists.
-        if let targetListName = listName, targetListName != reminder.calendar.title {
-            return try moveReminderAcrossLists(reminder, toListNamed: targetListName)
-        }
-
         return reminder.toJSON()
     }
 
-    /// Moves a reminder to a different list. Tries EventKit direct reassignment
-    /// first; on failure (e.g., cross-source moves that raise error -3002), falls
-    /// back to AppleScript's `move` command. AppleScript internally copy-and-deletes
-    /// while preserving metadata (title, notes, alarms, recurrence, creationDate),
-    /// mirroring Apple's own Reminders.app behavior. The returned JSON reflects
-    /// the reminder's new identifier in the target list.
-    private func moveReminderAcrossLists(_ reminder: EKReminder, toListNamed targetListName: String) throws -> ReminderJSON {
+    /// Moves a reminder to a different list and returns the (possibly new) EKReminder
+    /// in the target list. Tries EventKit direct reassignment first; on failure (e.g.,
+    /// cross-source moves that raise com.apple.reminderkit error -3002), falls back
+    /// to AppleScript's `move` command. AppleScript internally copy-and-deletes while
+    /// preserving all metadata including creationDate, mirroring Apple's own
+    /// Reminders.app behavior when a user drags a reminder between lists.
+    private func moveReminderAcrossLists(_ reminder: EKReminder, toListNamed targetListName: String) throws -> EKReminder {
         let targetList = try findList(named: targetListName)
         let originalTitle = reminder.title ?? ""
         let originalCreationDate = reminder.creationDate
@@ -908,14 +908,14 @@ class RemindersManager {
         reminder.calendar = targetList
         do {
             try eventStore.save(reminder, commit: true)
-            return reminder.toJSON()
+            return reminder
         } catch {
-            try runAppleScriptMove(reminderUUID: originalUUID, toListNamed: targetListName)
+            try runAppleScriptMove(reminderUUID: originalUUID, toListNamed: targetList.title)
             eventStore.refreshSourcesIfNecessary()
             if let moved = findReminderInList(targetList, matchingTitle: originalTitle, creationDate: originalCreationDate) {
-                return moved.toJSON()
+                return moved
             }
-            throw NSError(domain: "EventKitCLI", code: 500, userInfo: [NSLocalizedDescriptionKey: "Cross-list move completed via AppleScript but the moved reminder could not be located in '\(targetListName)'. The underlying error from EventKit was: \(error.localizedDescription)"])
+            throw NSError(domain: "EventKitCLI", code: 500, userInfo: [NSLocalizedDescriptionKey: "Cross-list move completed via AppleScript but the moved reminder could not be located in '\(targetList.title)'. The underlying error from EventKit was: \(error.localizedDescription)"])
         }
     }
 
@@ -928,11 +928,14 @@ class RemindersManager {
         end tell
         """
         let process = Process()
-        process.launchPath = "/usr/bin/osascript"
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
         process.arguments = ["-e", script]
         let errPipe = Pipe()
         process.standardError = errPipe
-        process.standardOutput = Pipe()
+        // Discard stdout; not reading from a Pipe can deadlock if output exceeds the
+        // pipe buffer (~64 KB). `osascript move` normally emits nothing, but using
+        // the null device is safer than a Pipe we never drain.
+        process.standardOutput = FileHandle.nullDevice
         try process.run()
         process.waitUntilExit()
         if process.terminationStatus != 0 {

--- a/src/swift/EventKitCLI.swift
+++ b/src/swift/EventKitCLI.swift
@@ -748,6 +748,11 @@ class RemindersManager {
 
     func updateReminder(id: String, newTitle: String?, listName: String?, notes: String?, location: String?, urlString: String?, isCompleted: Bool?, completionDateString: String?, startDateString: String?, dueDateString: String?, priority: Int?, alarmsJSON: String?, clearAlarms: Bool?, recurrenceRulesJSON: String?, clearRecurrence: Bool?, locationTriggerJSON: String?, clearLocationTrigger: Bool?) throws -> ReminderJSON {
         guard let reminder = findReminder(withId: id) else { throw NSError(domain: "", code: 404, userInfo: [NSLocalizedDescriptionKey: "ID '\(id)' not found."]) }
+        // Validate target list exists upfront so a bad list name doesn't cause a
+        // partial update where other fields commit before the move error surfaces.
+        if let targetListName = listName, targetListName != reminder.calendar.title {
+            _ = try findList(named: targetListName)
+        }
         if let newTitle = newTitle { reminder.title = newTitle }
         if let location = location {
             reminder.location = location.isEmpty ? nil : location
@@ -848,8 +853,6 @@ class RemindersManager {
             reminder.addAlarm(alarm)
         }
 
-        if let listName = listName { reminder.calendar = try findList(named: listName) }
-
         var startTz: TimeZone?
         if let startStr = startDateString {
             if let parsedComponents = parseDateComponents(from: startStr) {
@@ -878,7 +881,87 @@ class RemindersManager {
         }
 
         try eventStore.save(reminder, commit: true)
+
+        // Handle cross-list move separately. EventKit cannot reassign `calendar`
+        // on a saved reminder across sources (raises com.apple.reminderkit error
+        // -3002), so we fall back to AppleScript's `move` command which preserves
+        // all metadata including creationDate. See moveReminderAcrossLists.
+        if let targetListName = listName, targetListName != reminder.calendar.title {
+            return try moveReminderAcrossLists(reminder, toListNamed: targetListName)
+        }
+
         return reminder.toJSON()
+    }
+
+    /// Moves a reminder to a different list. Tries EventKit direct reassignment
+    /// first; on failure (e.g., cross-source moves that raise error -3002), falls
+    /// back to AppleScript's `move` command. AppleScript internally copy-and-deletes
+    /// while preserving metadata (title, notes, alarms, recurrence, creationDate),
+    /// mirroring Apple's own Reminders.app behavior. The returned JSON reflects
+    /// the reminder's new identifier in the target list.
+    private func moveReminderAcrossLists(_ reminder: EKReminder, toListNamed targetListName: String) throws -> ReminderJSON {
+        let targetList = try findList(named: targetListName)
+        let originalTitle = reminder.title ?? ""
+        let originalCreationDate = reminder.creationDate
+        let originalUUID = reminder.calendarItemIdentifier
+
+        reminder.calendar = targetList
+        do {
+            try eventStore.save(reminder, commit: true)
+            return reminder.toJSON()
+        } catch {
+            try runAppleScriptMove(reminderUUID: originalUUID, toListNamed: targetListName)
+            eventStore.refreshSourcesIfNecessary()
+            if let moved = findReminderInList(targetList, matchingTitle: originalTitle, creationDate: originalCreationDate) {
+                return moved.toJSON()
+            }
+            throw NSError(domain: "EventKitCLI", code: 500, userInfo: [NSLocalizedDescriptionKey: "Cross-list move completed via AppleScript but the moved reminder could not be located in '\(targetListName)'. The underlying error from EventKit was: \(error.localizedDescription)"])
+        }
+    }
+
+    private func runAppleScriptMove(reminderUUID: String, toListNamed targetListName: String) throws {
+        let escapedList = targetListName.replacingOccurrences(of: "\\", with: "\\\\").replacingOccurrences(of: "\"", with: "\\\"")
+        let script = """
+        tell application "Reminders"
+            set src to first reminder whose id contains "\(reminderUUID)"
+            move src to list "\(escapedList)"
+        end tell
+        """
+        let process = Process()
+        process.launchPath = "/usr/bin/osascript"
+        process.arguments = ["-e", script]
+        let errPipe = Pipe()
+        process.standardError = errPipe
+        process.standardOutput = Pipe()
+        try process.run()
+        process.waitUntilExit()
+        if process.terminationStatus != 0 {
+            let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
+            let errString = String(data: errData, encoding: .utf8) ?? "unknown"
+            throw NSError(domain: "EventKitCLI", code: 500, userInfo: [NSLocalizedDescriptionKey: "AppleScript move failed: \(errString.trimmingCharacters(in: .whitespacesAndNewlines))"])
+        }
+    }
+
+    private func findReminderInList(_ list: EKCalendar, matchingTitle title: String, creationDate: Date?) -> EKReminder? {
+        let predicate = eventStore.predicateForReminders(in: [list])
+        var found: EKReminder?
+        let semaphore = DispatchSemaphore(value: 0)
+        eventStore.fetchReminders(matching: predicate) { reminders in
+            defer { semaphore.signal() }
+            guard let reminders = reminders else { return }
+            if let creationDate = creationDate {
+                found = reminders.first { reminder in
+                    guard (reminder.title ?? "") == title else { return false }
+                    guard let otherDate = reminder.creationDate else { return false }
+                    return abs(otherDate.timeIntervalSince(creationDate)) < 1.0
+                }
+            }
+            if found == nil {
+                found = reminders.first { ($0.title ?? "") == title }
+            }
+        }
+        semaphore.wait()
+        return found
     }
 
     func deleteReminder(id: String) throws {


### PR DESCRIPTION
Fixes #81

## Problem

Calling `reminders_tasks` with `action: update` and a `targetList` different from the reminder's current list fails with `com.apple.reminderkit error -3002`. The reminder stays in its original list. Reproducer and full context in the linked issue.

## Fix

`updateReminder` now:

1. Validates the target list exists upfront, so a bad list name no longer causes a partial update where other fields commit before the move fails.
2. Saves all non-calendar field changes normally.
3. If the target list differs from the current list, calls a new `moveReminderAcrossLists` helper that:
   - Tries the EventKit direct reassignment first (fast path, preserves UUID when EventKit allows the move).
   - On save error, falls back to AppleScript's `move` command via `osascript`. AppleScript copy-and-deletes internally while preserving all metadata including `creationDate`, mirroring Apple's own Reminders.app behavior.
   - Re-fetches the moved reminder by matching title and `creationDate` so the response reflects the new identifier.

## Verification

End-to-end tested on macOS 26 against live Reminders.app:

- Cross-list move succeeds, all metadata preserved (title, notes, URL, priority, due date, start date, timezone, alarms, recurrence rules, `creationDate`).
- Same-list move is a no-op (UUID preserved).
- Bad target list name returns a clean error without mutating the reminder.
- Move combined with other field updates in a single call applies everything atomically.

All 508 tests pass (9 of them new regression tests for the fallback path). Lint and typecheck clean.