### PR TITLE
feat: pre-built universal binary via npm with Developer ID signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,120 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+# Serialize release runs so rapid tag pushes don't race on `npm publish`.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: macos-latest
+
+    # id-token: write is required for `npm publish --provenance`, which binds
+    # the published tarball to this workflow run via Sigstore.
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.28.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Import Developer ID Application certificate
+        env:
+          APPLE_CERTIFICATE_BASE64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: |
+          security create-keychain -p "ci-keychain-password" build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p "ci-keychain-password" build.keychain
+          # Keep keychain unlocked for the duration of the job (6 hours)
+          security set-keychain-settings -lut 21600 build.keychain
+
+          echo "$APPLE_CERTIFICATE_BASE64" | base64 --decode > certificate.p12
+          security import certificate.p12 \
+            -k build.keychain \
+            -P "$APPLE_CERTIFICATE_PASSWORD" \
+            -T /usr/bin/codesign
+          rm certificate.p12
+
+          # Allow codesign to access the key without a password prompt
+          security set-key-partition-list \
+            -S apple-tool:,apple: \
+            -s -k "ci-keychain-password" build.keychain
+
+      - name: Build TypeScript
+        run: pnpm run build:ts
+
+      - name: Build universal Swift binary and sign
+        # resolveSigningIdentity() in build-swift.mjs auto-detects the
+        # Developer ID Application certificate imported in the previous step.
+        run: pnpm run build:swift
+
+      - name: Notarize binary
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: pnpm run notarize
+
+      - name: Verify binary
+        run: |
+          echo "=== Architecture ==="
+          lipo -info bin/EventKitCLI
+          echo "=== Code signature ==="
+          codesign -dv --verbose=2 bin/EventKitCLI
+
+      - name: Verify npm package contents
+        # Fail the build if the pre-built binary is not included in the tarball.
+        run: |
+          PACK_JSON="$(npm pack --json --dry-run)"
+          PACK_JSON="$PACK_JSON" node -e '
+            const [pack] = JSON.parse(process.env.PACK_JSON);
+            const files = new Set(pack.files.map((file) => file.path));
+            const requiredFiles = [
+              "bin/EventKitCLI",
+              "bin/run.cjs",
+              "dist/index.js",
+              "scripts/postinstall.mjs",
+              "scripts/build-swift.mjs",
+            ];
+            const missing = requiredFiles.filter((file) => !files.has(file));
+            if (missing.length > 0) {
+              console.error(`Missing package files: ${missing.join(", ")}`);
+              process.exit(1);
+            }
+          '
+
+      - name: Run tests
+        run: pnpm test
+
+      - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public --provenance
+
+      - name: Restore default keychain and clean up
+        if: always()
+        run: |
+          security default-keychain -s login.keychain 2>/dev/null || true
+          security delete-keychain build.keychain 2>/dev/null || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,10 @@ concurrency:
 
 jobs:
   release:
-    runs-on: macos-latest
+    # Pin to macos-14 (Sonoma) instead of macos-latest so deployment targets
+    # (-target arm64-apple-macos11.0, -target x86_64-apple-macos10.15) stay
+    # buildable as GitHub rotates runner images. Bumping is intentional.
+    runs-on: macos-14
 
     # id-token: write is required for `npm publish --provenance`, which binds
     # the published tarball to this workflow run via Sigstore.
@@ -44,6 +47,7 @@ jobs:
           APPLE_CERTIFICATE_BASE64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
         run: |
+          set -euo pipefail
           security create-keychain -p "ci-keychain-password" build.keychain
           security default-keychain -s build.keychain
           security unlock-keychain -p "ci-keychain-password" build.keychain
@@ -78,29 +82,48 @@ jobs:
         run: pnpm run notarize
 
       - name: Verify binary
+        # Belt-and-braces: assert the universal binary actually carries a
+        # Developer ID Application signature and passes a strict verify pass,
+        # so an accidentally-ad-hoc-signed build cannot reach `npm publish`.
         run: |
+          set -euo pipefail
           echo "=== Architecture ==="
-          lipo -info bin/EventKitCLI
+          lipo -info bin/EventKitCLI | tee /tmp/lipo.out
+          grep -q "are: x86_64 arm64\|are: arm64 x86_64" /tmp/lipo.out
           echo "=== Code signature ==="
-          codesign -dv --verbose=2 bin/EventKitCLI
+          codesign -dv --verbose=2 bin/EventKitCLI 2>&1 | tee /tmp/codesign.out
+          grep -q "Authority=Developer ID Application:" /tmp/codesign.out
+          grep -q "flags=0x10000(runtime)" /tmp/codesign.out
+          codesign --verify --strict --verbose=2 bin/EventKitCLI
 
       - name: Verify npm package contents
-        # Fail the build if the pre-built binary is not included in the tarball.
+        # Fail the build if the pre-built binary is not included in the
+        # tarball or if dead-weight `src/**/*.test.ts` slips in.
         run: |
+          set -euo pipefail
           PACK_JSON="$(npm pack --json --dry-run)"
           PACK_JSON="$PACK_JSON" node -e '
             const [pack] = JSON.parse(process.env.PACK_JSON);
             const files = new Set(pack.files.map((file) => file.path));
             const requiredFiles = [
               "bin/EventKitCLI",
-              "bin/run.cjs",
               "dist/index.js",
               "scripts/postinstall.mjs",
               "scripts/build-swift.mjs",
+              "src/swift/EventKitCLI.swift",
+              "src/swift/Info.plist",
+              "src/swift/EventKitCLI.entitlements",
             ];
             const missing = requiredFiles.filter((file) => !files.has(file));
             if (missing.length > 0) {
               console.error(`Missing package files: ${missing.join(", ")}`);
+              process.exit(1);
+            }
+            const forbidden = [...files].filter(
+              (path) => /\.test\.ts$/.test(path) || /\.spec\.ts$/.test(path),
+            );
+            if (forbidden.length > 0) {
+              console.error(`Dead-weight files in tarball: ${forbidden.join(", ")}`);
               process.exit(1);
             }
           '
@@ -116,5 +139,6 @@ jobs:
       - name: Restore default keychain and clean up
         if: always()
         run: |
+          set -euo pipefail
           security default-keychain -s login.keychain 2>/dev/null || true
           security delete-keychain build.keychain 2>/dev/null || true

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -33,7 +33,6 @@ export default {
     '!src/utils/projectUtils.ts', // Excluded: import.meta.url line cannot be tested in Jest
   ],
   coveragePathIgnorePatterns: ['/node_modules/', '/dist/'],
-  // Ignore import.meta.url line in projectUtils.ts
   coverageReporters: ['text', 'text-summary', 'html'],
   // Thresholds set just below the suite's current ceiling — leaves a thin
   // buffer for unrelated future patches without papering over regressions.

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "mcp-server-apple-events": "./dist/index.js"
   },
   "files": [
-    "dist",
+    "bin/EventKitCLI",
+    "dist/",
     "scripts/postinstall.mjs",
     "scripts/build-swift.mjs",
     "src/swift/EventKitCLI.swift",
@@ -38,16 +39,9 @@
   "engines": {
     "node": ">=20.0.0"
   },
-  "files": [
-    "bin/",
-    "dist/",
-    "scripts/postinstall.mjs",
-    "scripts/build-swift.mjs",
-    "src/"
-  ],
   "scripts": {
     "clean": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\"",
-    "build:ts": "tsc -p tsconfig.json",
+    "build:ts": "tsc -p tsconfig.build.json",
     "build:swift": "node scripts/build-swift.mjs",
     "build": "pnpm run clean && pnpm run build:ts && pnpm run build:swift",
     "notarize": "node scripts/notarize.mjs",

--- a/package.json
+++ b/package.json
@@ -38,11 +38,20 @@
   "engines": {
     "node": ">=20.0.0"
   },
+  "files": [
+    "bin/",
+    "dist/",
+    "scripts/postinstall.mjs",
+    "scripts/build-swift.mjs",
+    "src/"
+  ],
   "scripts": {
     "clean": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\"",
     "build:ts": "tsc -p tsconfig.json",
     "build:swift": "node scripts/build-swift.mjs",
     "build": "pnpm run clean && pnpm run build:ts && pnpm run build:swift",
+    "notarize": "node scripts/notarize.mjs",
+    "build:release": "pnpm run clean && pnpm run build:ts && pnpm run build:swift && pnpm run notarize",
     "postinstall": "node scripts/postinstall.mjs",
     "test": "NODE_NO_WARNINGS=1 jest",
     "test:ci": "NODE_NO_WARNINGS=1 jest --coverage",

--- a/scripts/build-swift.mjs
+++ b/scripts/build-swift.mjs
@@ -99,9 +99,62 @@ function looksLikeFoundationModuleMismatch(stderr) {
   );
 }
 
-function swiftArchForHost() {
-  // Swift target triples use `arm64` and `x86_64`; Node reports `arm64` and `x64`.
-  return process.arch === 'arm64' ? 'arm64' : 'x86_64';
+/**
+ * Resolves the code-signing identity to use.
+ *
+ * Priority order:
+ *   1. APPLE_SIGNING_IDENTITY env var (explicit override)
+ *   2. First "Developer ID Application:" cert found in the login keychain
+ *   3. Ad-hoc ("-") with a warning
+ *
+ * A Developer ID signature makes EventKitCLI the TCC-responsible process
+ * regardless of which parent process spawned it, fixing Calendar permission
+ * dialogs on OCLP Sequoia and macOS 26+.
+ */
+async function resolveSigningIdentity() {
+  if (process.env.APPLE_SIGNING_IDENTITY) {
+    return process.env.APPLE_SIGNING_IDENTITY;
+  }
+
+  try {
+    const { stdout } = await run('security', [
+      'find-identity',
+      '-v',
+      '-p',
+      'codesigning',
+    ]);
+    const lines = stdout.split('\n');
+
+    // Prefer Developer ID Application (trusted on all Macs) over Apple Development
+    // (trusted only on the developer's own machine, but sufficient for local use).
+    for (const prefix of ['Developer ID Application:', 'Apple Development:']) {
+      const matches = lines.filter((line) => line.includes(prefix));
+      if (matches.length === 1) {
+        const m = matches[0].match(/"([^"]+)"/);
+        if (m) return m[1];
+      }
+      if (matches.length > 1) {
+        console.warn(`Multiple "${prefix}" certificates found in keychain.`);
+        console.warn(
+          'Set APPLE_SIGNING_IDENTITY to the exact certificate name to avoid ambiguity.',
+        );
+        break;
+      }
+    }
+  } catch {
+    // security binary unavailable — fall through to ad-hoc
+  }
+
+  console.warn(
+    'No Apple code-signing certificate found. Using ad-hoc signing (-).',
+  );
+  console.warn(
+    'Calendar TCC permission dialogs may be suppressed on OCLP Sequoia and macOS 26+.',
+  );
+  console.warn(
+    'To fix this, set APPLE_SIGNING_IDENTITY="Developer ID Application: Your Name (TEAMID)".',
+  );
+  return '-';
 }
 
 async function main() {
@@ -127,6 +180,18 @@ async function main() {
     process.exit(1);
   }
 
+  try {
+    await run('xcrun', ['--find', 'lipo']);
+  } catch (_error) {
+    console.error(
+      'Error: lipo not found. Required for universal binary creation.',
+    );
+    console.error(
+      'Please install Xcode or Xcode Command Line Tools: xcode-select --install',
+    );
+    process.exit(1);
+  }
+
   // Resolve paths relative to script location, not process.cwd()
   const __filename = fileURLToPath(import.meta.url);
   const __dirname = path.dirname(__filename);
@@ -137,6 +202,8 @@ async function main() {
   const entitlementsFile = path.join(scriptDir, 'EventKitCLI.entitlements');
   const binDir = path.join(projectRoot, 'bin');
   const outputFile = path.join(binDir, 'EventKitCLI');
+  const arm64File = path.join(binDir, 'EventKitCLI-arm64');
+  const x86File = path.join(binDir, 'EventKitCLI-x86_64');
 
   try {
     await fs.access(sourceFile);
@@ -167,27 +234,14 @@ async function main() {
 
   await fs.mkdir(binDir, { recursive: true });
 
-  // Pin deployment target to macOS 13.0 — the lowest the Swift source supports
-  // via its `requestAccess(to: .reminder)` legacy branch. Pinning keeps the
-  // build deterministic across SDK versions and avoids defaulting to the host
-  // SDK's target, which on macOS 26 makes the macOS-14 fallback path appear
-  // unreachable.
-  const target = `${swiftArchForHost()}-apple-macosx13.0`;
+  // Build a universal (fat) binary containing both arm64 and x86_64 slices.
+  // Each slice is compiled separately with its appropriate deployment target,
+  // then merged via lipo. This ensures the same npm package works on both
+  // Apple Silicon (arm64, macOS 11+) and Intel (x86_64, macOS 10.15+) Macs.
   // `xcrun -sdk macosx swiftc` keeps the toolchain and SDK xcode-select resolves
   // consistent. -Xlinker embeds Info.plist so macOS shows EventKit prompts.
-  const compileArgs = [
-    '-sdk',
-    'macosx',
-    'swiftc',
-    '-target',
-    target,
-    '-o',
-    outputFile,
-    sourceFile,
-    '-framework',
-    'EventKit',
-    '-framework',
-    'Foundation',
+  const frameworkArgs = ['-framework', 'EventKit', '-framework', 'Foundation'];
+  const linkerArgs = [
     '-Xlinker',
     '-sectcreate',
     '-Xlinker',
@@ -198,42 +252,97 @@ async function main() {
     infoPlistFile,
   ];
 
-  console.log(`Compiling ${sourceFile} (target ${target})...`);
+  const slices = [
+    { file: arm64File, target: 'arm64-apple-macos11.0', label: 'arm64' },
+    { file: x86File, target: 'x86_64-apple-macos10.15', label: 'x86_64' },
+  ];
+
+  console.log(`Compiling ${sourceFile} (arm64 + x86_64)...`);
 
   try {
-    const { stdout, stderr } = await run('xcrun', compileArgs);
-    if (stderr) {
-      console.warn(`Swift compiler warnings:\n${stderr}`);
-    }
-    if (stdout) {
-      console.log(stdout);
-    }
+    // Slices are independent — compile in parallel to roughly halve build time.
+    // `xcrun -sdk macosx swiftc` keeps the toolchain and SDK xcode-select
+    // resolves consistent across both slices.
+    const results = await Promise.all(
+      slices.map((s) =>
+        run('xcrun', [
+          '-sdk',
+          'macosx',
+          'swiftc',
+          '-target',
+          s.target,
+          '-o',
+          s.file,
+          sourceFile,
+          ...frameworkArgs,
+          ...linkerArgs,
+        ]),
+      ),
+    );
+    results.forEach(({ stdout, stderr }, i) => {
+      if (stderr)
+        console.warn(`${slices[i].label} compiler warnings:\n${stderr}`);
+      if (stdout) console.log(stdout);
+    });
 
-    console.log(`Compilation successful! Binary saved to ${outputFile}`);
+    await run('xcrun', [
+      'lipo',
+      '-create',
+      '-output',
+      outputFile,
+      arm64File,
+      x86File,
+    ]);
+
+    await Promise.all([fs.unlink(arm64File), fs.unlink(x86File)]);
+
+    console.log(
+      `Compilation successful! Universal binary saved to ${outputFile}`,
+    );
 
     await fs.chmod(outputFile, '755');
     console.log('Binary is now executable.');
 
-    // --options runtime enables Hardened Runtime, required on macOS 26+ for
-    // the TCC system to show calendar permission dialogs when the binary
-    // runs as a subprocess of a GUI application (e.g. Claude Desktop).
-    const { stdout: csOut, stderr: csErr } = await run('codesign', [
+    const signingIdentity = await resolveSigningIdentity();
+    const isAdHoc = signingIdentity === '-';
+
+    console.log(
+      isAdHoc
+        ? 'Signing with ad-hoc identity...'
+        : `Signing with Developer ID: ${signingIdentity}`,
+    );
+
+    // --options runtime: Hardened Runtime, required on macOS 26+ for the TCC
+    //   system to show calendar permission dialogs when the binary runs as a
+    //   subprocess of a GUI application (e.g. Claude Desktop).
+    // --timestamp: secure timestamp from Apple CA; included for Developer ID
+    //   signatures to ensure long-term validity; omitted for ad-hoc (no CA).
+    const codesignArgs = [
       '--force',
       '--sign',
-      '-',
+      signingIdentity,
       '--options',
       'runtime',
+      ...(isAdHoc ? [] : ['--timestamp']),
       '--entitlements',
       entitlementsFile,
       outputFile,
-    ]);
+    ];
+    const { stdout: csOut, stderr: csErr } = await run(
+      'codesign',
+      codesignArgs,
+    );
     if (csErr) {
       console.warn(`codesign warnings:\n${csErr}`);
     }
     if (csOut) {
       console.log(csOut);
     }
-    console.log('Binary signed with hardened runtime and entitlements.');
+    console.log(
+      isAdHoc
+        ? 'Binary signed (ad-hoc) with hardened runtime and entitlements.'
+        : 'Binary signed with Developer ID, hardened runtime, and entitlements.',
+    );
     console.log('Swift binary build complete!');
   } catch (error) {
     console.error('Compilation failed!');

--- a/scripts/notarize.mjs
+++ b/scripts/notarize.mjs
@@ -1,0 +1,118 @@
+import { execFile } from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = path.resolve(__dirname, '..');
+const binDir = path.join(projectRoot, 'bin');
+const outputFile = path.join(binDir, 'EventKitCLI');
+const zipFile = path.join(binDir, 'EventKitCLI.zip');
+
+async function main() {
+  try {
+    await fs.access(outputFile, fs.constants.F_OK);
+  } catch {
+    console.error(`Error: Binary not found at ${outputFile}`);
+    console.error('Run `pnpm run build:swift` first.');
+    process.exit(1);
+  }
+
+  const appleId = process.env.APPLE_ID;
+  const appPassword = process.env.APPLE_APP_PASSWORD;
+  const teamId = process.env.APPLE_TEAM_ID;
+
+  if (!appleId || !appPassword || !teamId) {
+    const message =
+      'APPLE_ID, APPLE_APP_PASSWORD, and APPLE_TEAM_ID must all be set.';
+    if (process.env.CI) {
+      console.error(`Notarization failed: ${message}`);
+      process.exit(1);
+    }
+
+    console.warn(`Notarization skipped: ${message}`);
+    console.warn(
+      'For local builds this is expected. Set these variables to enable notarization.',
+    );
+    process.exit(0);
+  }
+
+  try {
+    await execFileAsync('xcrun', ['notarytool', '--version']);
+  } catch {
+    console.error(
+      'Error: xcrun notarytool not found. Install Xcode 13+ or Xcode Command Line Tools.',
+    );
+    process.exit(1);
+  }
+
+  console.log('Creating zip archive for notarization...');
+  await execFileAsync('ditto', [
+    '-c',
+    '-k',
+    '--keepParent',
+    outputFile,
+    zipFile,
+  ]);
+
+  console.log(
+    'Submitting to Apple notary service (this may take a few minutes)...',
+  );
+  // Pass credentials via argv array (not shell interpolation) so special
+  // characters are safe and the password isn't parsed by any shell.
+  // Note: argv is still visible via `ps` on the host — on an isolated CI
+  // runner this is acceptable; for local use prefer `xcrun notarytool
+  // store-credentials` + `--keychain-profile` instead.
+  let submissionOutput = '';
+  try {
+    const { stdout } = await execFileAsync('xcrun', [
+      'notarytool',
+      'submit',
+      zipFile,
+      '--apple-id',
+      appleId,
+      '--password',
+      appPassword,
+      '--team-id',
+      teamId,
+      '--wait',
+    ]);
+    submissionOutput = stdout;
+  } catch (error) {
+    // notarytool exits non-zero when submission is rejected; capture the output
+    const execError = error;
+    submissionOutput = execError.stdout ?? '';
+    if (!submissionOutput) {
+      console.error('Notarization submission failed:', execError.message);
+      throw error;
+    }
+  } finally {
+    // Always clean up the zip regardless of outcome
+    await fs.unlink(zipFile).catch(() => {});
+  }
+
+  console.log('Notarization response:\n', submissionOutput);
+
+  if (/status:\s+Accepted/i.test(submissionOutput)) {
+    console.log('Notarization accepted.');
+    // Stapling is not supported for standalone binaries (only .app, .dmg, .pkg).
+    // Gatekeeper performs an online check at first launch for non-stapled binaries.
+    // npm-installed files carry no quarantine xattr, so the online check is a
+    // no-op in practice, but the notarization ticket is still useful for any
+    // future distribution channel that applies quarantine.
+  } else {
+    console.error(
+      'Notarization was NOT accepted. See response above for details.',
+    );
+    process.exit(1);
+  }
+}
+
+main().catch((error) => {
+  console.error('An unexpected error occurred during notarization:', error);
+  process.exit(1);
+});

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -3,55 +3,60 @@
 /**
  * Postinstall script for mcp-server-apple-events
  *
- * This script attempts to build the Swift binary on macOS during installation.
- * It gracefully skips on non-macOS platforms or if Swift is not available.
+ * When the package is installed via npm, the pre-built EventKitCLI binary is
+ * included in the package and this script exits immediately. No Xcode required.
+ *
+ * When the repository is cloned locally (no pre-built binary), this script
+ * attempts to build the Swift binary from source. It gracefully skips on
+ * non-macOS platforms or if Swift is not available.
  */
 
 import { execFile } from 'node:child_process';
+import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const projectRoot = path.resolve(__dirname, '..');
 
-const isMacOS = process.platform === 'darwin';
+async function main() {
+  if (process.platform !== 'darwin') {
+    console.log('Skipping Swift binary build on non-macOS platform');
+    process.exit(0);
+  }
 
-if (!isMacOS) {
-  console.log('Skipping Swift binary build on non-macOS platform');
-  process.exit(0);
+  // If the pre-built binary is already present (npm install from published package),
+  // skip the source build entirely.
+  const binPath = path.join(projectRoot, 'bin', 'EventKitCLI');
+  try {
+    await fs.access(binPath, fs.constants.X_OK);
+    console.log('Pre-built EventKitCLI binary found, skipping source build.');
+    process.exit(0);
+  } catch {
+    // Binary not present or not executable — proceed to build from source
+  }
+
+  await buildSwift();
 }
 
-const buildSwift = async () => {
-  return new Promise((resolve, reject) => {
-    const buildScript = path.join(projectRoot, 'scripts', 'build-swift.mjs');
-
-    // `execFile` (not `exec`) so the install path is passed as a discrete argv
-    // entry instead of being interpolated into a shell command. This keeps the
-    // build deterministic even when the project lives under a directory that
-    // contains spaces, `$`, backticks, or other shell-significant characters.
-    execFile(
-      process.execPath,
-      [buildScript],
-      { cwd: projectRoot },
-      (error, stdout, stderr) => {
-        if (error) {
-          console.error('Swift binary build failed:', error.message);
-          if (stderr) {
-            console.error('Build error:', stderr);
-          }
-          reject(error);
-          return;
-        }
-        if (stdout) {
-          console.log(stdout);
-        }
-        resolve(stdout);
-      },
-    );
+// `execFile` (not `exec`) so the install path is passed as a discrete argv
+// entry instead of being interpolated into a shell command. This keeps the
+// build deterministic even when the project lives under a directory that
+// contains spaces, `$`, backticks, or other shell-significant characters.
+async function buildSwift() {
+  const buildScript = path.join(projectRoot, 'scripts', 'build-swift.mjs');
+  const { stdout } = await execFileAsync(process.execPath, [buildScript], {
+    cwd: projectRoot,
   });
-};
+  if (stdout) {
+    console.log(stdout);
+  }
+}
 
-buildSwift()
+main()
   .then(() => {
     console.log('Swift binary built successfully');
     process.exit(0);
@@ -64,14 +69,8 @@ buildSwift()
     console.error(
       '\nThe MCP server requires the EventKitCLI binary to function.',
     );
-    console.error('\nTo build manually:');
-    console.error('  1. Navigate to the package directory');
-    console.error('  2. Run: pnpm install && pnpm run build');
-    console.error('\nOr use a local clone instead of npx:');
-    console.error(
-      '  git clone https://github.com/fradser/mcp-server-apple-events.git',
-    );
-    console.error('  cd mcp-server-apple-events && pnpm install && pnpm build');
+    console.error('\nTo build manually, run from the package directory:');
+    console.error('  pnpm install && pnpm run build');
     console.error(`${'='.repeat(70)}\n`);
     process.exit(0); // Exit gracefully to not block installation
   });

--- a/src/publishedPackage.test.ts
+++ b/src/publishedPackage.test.ts
@@ -143,12 +143,14 @@ describe('published npm tarball', () => {
   });
 
   describe('size sanity', () => {
-    it('keeps the unpacked tarball under 2MB', () => {
-      // The pre-allowlist tarball was 4.1MB unpacked. 2MB is a comfortable
-      // ceiling that still leaves room for the dist/ output to grow, while
-      // catching accidental re-inclusion of the vendor/ tree (~1.7MB).
+    it('keeps the unpacked tarball under 3MB', () => {
+      // The universal `bin/EventKitCLI` is ~1.5MB on its own (arm64 + x86_64
+      // slices); the rest of the tarball (compiled dist/, scripts, Swift
+      // sources, READMEs) sits in the 600-800KB band. 3MB leaves headroom
+      // for dist/ to grow while still flagging accidental re-inclusion of
+      // the vendor/ tree (~1.7MB) or test files via dist/.
       const unpacked = pack.files.reduce((sum, f) => sum + f.size, 0);
-      expect(unpacked).toBeLessThan(2 * 1024 * 1024);
+      expect(unpacked).toBeLessThan(3 * 1024 * 1024);
     });
   });
 });

--- a/src/server/promptAbstractions.ts
+++ b/src/server/promptAbstractions.ts
@@ -1,11 +1,4 @@
 /**
- * @fileoverview Shared abstractions for prompt templates
- * @module server/promptAbstractions
- * @description Output formats and constraints shared across all prompt templates
- * Provides consistent behavior for action execution based on confidence thresholds
- */
-
-/**
  * Standard confidence system constraints
  * Decision priority: (1) If scope is ambiguous → confirm, (2) Then apply confidence thresholds
  */
@@ -138,10 +131,7 @@ export const TIME_BLOCK_CREATION_CONSTRAINTS = [
   '  - Follow confidence gating (execute >80%, recommend 60-80, confirm <60).',
 ];
 
-/**
- * Standard action queue output format
- */
-export const getActionQueueFormat = (_currentDate: string): string[] => [
+const ACTION_QUEUE_FORMAT: string[] = [
   '### Action queue',
   '',
   '**HIGH CONFIDENCE (>80%)**: Execute immediately with tool calls. After execution, show:',
@@ -159,21 +149,12 @@ export const getActionQueueFormat = (_currentDate: string): string[] => [
   `  - Use ${TIME_FORMAT_SPEC} format for dueDate (e.g., "2025-11-04 18:00:00-05:00").`,
 ];
 
-/**
- * Standard verification log format
- */
-export const getVerificationLogFormat = (currentDate: string): string =>
-  `### Verification log — bullet list confirming that each executed due date marked "today" uses ${currentDate} in the tool call output and persisted value (include reminder title + due date).`;
-
-/**
- * Build standard output format sections
- */
 export const buildStandardOutputFormat = (
   currentDate: string,
 ): {
   actionQueue: string[];
   verificationLog: string;
 } => ({
-  actionQueue: getActionQueueFormat(currentDate),
-  verificationLog: getVerificationLogFormat(currentDate),
+  actionQueue: ACTION_QUEUE_FORMAT,
+  verificationLog: `### Verification log — bullet list confirming that each executed due date marked "today" uses ${currentDate} in the tool call output and persisted value (include reminder title + due date).`,
 });

--- a/src/swift/build-swift.test.ts
+++ b/src/swift/build-swift.test.ts
@@ -7,15 +7,17 @@ describe('build-swift.mjs code signing', () => {
   const buildScript = readFileSync(buildScriptPath, 'utf8');
 
   it('signs binary with hardened runtime for macOS 26+ TCC compatibility', () => {
-    expect(buildScript).toMatch(/codesign[\s\S]*?--options[\s\S]*?runtime/);
+    expect(buildScript).toMatch(/'--options'\s*,\s*\n?\s*'runtime'/);
   });
 
   it('embeds Info.plist into binary via linker', () => {
-    expect(buildScript).toMatch(/-Xlinker[\s\S]*?__info_plist/);
+    expect(buildScript).toMatch(/'__info_plist'/);
+    expect(buildScript).toMatch(/infoPlistFile/);
   });
 
   it('applies entitlements during code signing', () => {
-    expect(buildScript).toMatch(/codesign[\s\S]*?--entitlements/);
+    expect(buildScript).toMatch(/'--entitlements'/);
+    expect(buildScript).toMatch(/entitlementsFile/);
   });
 });
 
@@ -23,18 +25,9 @@ describe('build-swift.mjs toolchain resolution', () => {
   const buildScript = readFileSync(buildScriptPath, 'utf8');
 
   it('invokes swiftc via xcrun so SDK and toolchain stay consistent', () => {
-    expect(buildScript).toMatch(/xcrun\s+(?:-sdk\s+macosx\s+)?swiftc/);
-  });
-
-  it('pins -target to macosx13.0 (lowest supported deployment)', () => {
-    // Target triple may be built via a variable; just assert both the flag and
-    // the deployment string are present in the script.
-    expect(buildScript).toMatch(/-target/);
-    expect(buildScript).toMatch(/apple-macosx13\.0/);
-  });
-
-  it('derives swift target arch from the host (process.arch)', () => {
-    expect(buildScript).toMatch(/process\.arch/);
+    expect(buildScript).toMatch(/xcrun/);
+    expect(buildScript).toMatch(/'-sdk'\s*,\s*\n?\s*'macosx'/);
+    expect(buildScript).toMatch(/'swiftc'/);
   });
 });
 
@@ -55,5 +48,59 @@ describe('build-swift.mjs toolchain/SDK compatibility (issue #85)', () => {
     expect(buildScript).toMatch(
       /could not build module 'Foundation'|SDK is not supported by the compiler/,
     );
+  });
+});
+
+describe('build-swift.mjs code-signing identity', () => {
+  const buildScript = readFileSync(buildScriptPath, 'utf8');
+
+  it('resolves signing identity from APPLE_SIGNING_IDENTITY env var', () => {
+    expect(buildScript).toMatch(/APPLE_SIGNING_IDENTITY/);
+  });
+
+  it('auto-detects Developer ID Application and Apple Development certificates from keychain', () => {
+    expect(buildScript).toMatch(/Developer ID Application/);
+    expect(buildScript).toMatch(/Apple Development/);
+    expect(buildScript).toMatch(/'find-identity'/);
+  });
+
+  it('falls back to ad-hoc signing when no Developer ID is found', () => {
+    expect(buildScript).toMatch(/resolveSigningIdentity/);
+    // ad-hoc sentinel
+    expect(buildScript).toMatch(/return\s+['"]-['"]/);
+  });
+
+  it('includes secure timestamp flag for Developer ID signatures', () => {
+    expect(buildScript).toMatch(/--timestamp/);
+    expect(buildScript).toMatch(/isAdHoc/);
+  });
+});
+
+describe('build-swift.mjs universal binary', () => {
+  const buildScript = readFileSync(buildScriptPath, 'utf8');
+
+  it('builds arm64 slice with correct deployment target', () => {
+    expect(buildScript).toMatch(/'arm64-apple-macos11\.0'/);
+  });
+
+  it('builds x86_64 slice with correct deployment target', () => {
+    expect(buildScript).toMatch(/'x86_64-apple-macos10\.15'/);
+  });
+
+  it('merges slices into universal binary using lipo', () => {
+    expect(buildScript).toMatch(/'lipo'/);
+    expect(buildScript).toMatch(/'-create'/);
+  });
+
+  it('cleans up thin slice intermediates after lipo merge', () => {
+    expect(buildScript).toMatch(/EventKitCLI-arm64/);
+    expect(buildScript).toMatch(/EventKitCLI-x86_64/);
+  });
+
+  it('invokes external binaries via execFile (argv array, no shell interpolation)', () => {
+    // execFile is used instead of exec, preventing shell injection through
+    // signing-identity or path values.
+    expect(buildScript).toMatch(/execFile/);
+    expect(buildScript).not.toMatch(/\bpromisify\(exec\)/);
   });
 });

--- a/src/swift/notarize.test.ts
+++ b/src/swift/notarize.test.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const notarizeScriptPath = path.resolve(process.cwd(), 'scripts/notarize.mjs');
+
+describe('notarize.mjs', () => {
+  const notarizeScript = readFileSync(notarizeScriptPath, 'utf8');
+
+  it('skips missing notarization env vars only outside CI', () => {
+    expect(notarizeScript).toMatch(/APPLE_ID/);
+    expect(notarizeScript).toMatch(/APPLE_APP_PASSWORD/);
+    expect(notarizeScript).toMatch(/APPLE_TEAM_ID/);
+    expect(notarizeScript).toMatch(/process\.env\.CI/);
+    expect(notarizeScript).toMatch(/process\.exit\(0\)/);
+    expect(notarizeScript).toMatch(/process\.exit\(1\)/);
+  });
+
+  it('uses ditto to create zip archive for submission', () => {
+    expect(notarizeScript).toMatch(/execFileAsync\(\s*'ditto'/);
+    expect(notarizeScript).toMatch(/'--keepParent'/);
+    expect(notarizeScript).toMatch(/EventKitCLI\.zip/);
+  });
+
+  it('submits via xcrun notarytool with --wait flag', () => {
+    expect(notarizeScript).toMatch(/'notarytool'/);
+    expect(notarizeScript).toMatch(/'submit'/);
+    expect(notarizeScript).toMatch(/'--wait'/);
+  });
+
+  it('checks submission result for Accepted status', () => {
+    expect(notarizeScript).toMatch(/status.*Accepted/i);
+  });
+
+  it('cleans up zip file after submission', () => {
+    expect(notarizeScript).toMatch(/unlink.*zip/i);
+  });
+
+  it('exits with error when notarization is not accepted', () => {
+    expect(notarizeScript).toMatch(/process\.exit\(1\)/);
+  });
+
+  it('passes credentials via execFile argv (no shell interpolation)', () => {
+    // Password must not be interpolated into a shell command string where it
+    // would be exposed to word splitting or leak through shell tracing.
+    expect(notarizeScript).toMatch(/execFile/);
+    expect(notarizeScript).not.toMatch(/\bpromisify\(exec\)/);
+  });
+});

--- a/src/swift/package-release.test.ts
+++ b/src/swift/package-release.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const packageJsonPath = path.resolve(process.cwd(), 'package.json');
+const releaseWorkflowPath = path.resolve(
+  process.cwd(),
+  '.github/workflows/release.yml',
+);
+
+describe('release package contents', () => {
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+  const releaseWorkflow = readFileSync(releaseWorkflowPath, 'utf8');
+
+  it('ships the fallback Swift build script used by postinstall', () => {
+    expect(packageJson.files).toContain('scripts/postinstall.mjs');
+    expect(packageJson.files).toContain('scripts/build-swift.mjs');
+    expect(packageJson.files).toContain('src/');
+  });
+
+  it('verifies the exact pre-built binary path before publishing', () => {
+    expect(releaseWorkflow).toMatch(/npm pack --json --dry-run/);
+    expect(releaseWorkflow).toMatch(/bin\/EventKitCLI/);
+    expect(releaseWorkflow).not.toMatch(/grep -qE .*EventKitCLI\(\[\^\.]/);
+  });
+});

--- a/src/swift/package-release.test.ts
+++ b/src/swift/package-release.test.ts
@@ -11,15 +11,32 @@ describe('release package contents', () => {
   const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
   const releaseWorkflow = readFileSync(releaseWorkflowPath, 'utf8');
 
-  it('ships the fallback Swift build script used by postinstall', () => {
+  it('ships the fallback Swift build inputs used by postinstall', () => {
     expect(packageJson.files).toContain('scripts/postinstall.mjs');
     expect(packageJson.files).toContain('scripts/build-swift.mjs');
-    expect(packageJson.files).toContain('src/');
+    // build-swift.mjs reads these three files at install time when no
+    // pre-built binary is present.
+    expect(packageJson.files).toContain('src/swift/EventKitCLI.swift');
+    expect(packageJson.files).toContain('src/swift/Info.plist');
+    expect(packageJson.files).toContain('src/swift/EventKitCLI.entitlements');
+  });
+
+  it('does not ship the full src/ tree (no tests, no compiled output)', () => {
+    // Wildcards in `files` would re-add `*.test.ts` and Swift bridge tests
+    // to consumers' node_modules for no benefit.
+    expect(packageJson.files).not.toContain('src/');
+    expect(packageJson.files).not.toContain('src/**');
   });
 
   it('verifies the exact pre-built binary path before publishing', () => {
     expect(releaseWorkflow).toMatch(/npm pack --json --dry-run/);
     expect(releaseWorkflow).toMatch(/bin\/EventKitCLI/);
     expect(releaseWorkflow).not.toMatch(/grep -qE .*EventKitCLI\(\[\^\.]/);
+  });
+
+  it('pins the CI runner image and fails on non-Developer-ID signatures', () => {
+    expect(releaseWorkflow).toMatch(/runs-on: macos-14/);
+    expect(releaseWorkflow).toMatch(/Authority=Developer ID Application:/);
+    expect(releaseWorkflow).toMatch(/codesign --verify --strict/);
   });
 });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,12 +4,6 @@
  */
 
 /**
- * Priority levels for reminders (native EventKit values)
- * 0 = none, 1 = high, 2 = medium, 3 = low
- */
-export type ReminderPriority = 0 | 1 | 2 | 3;
-
-/**
  * Priority label mapping for display
  */
 export const PRIORITY_LABELS: Record<number, string> = {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -76,10 +76,8 @@ export const TIME = {
  * Error message templates
  */
 export const MESSAGES = {
-  /** Error messages */
   ERROR: {
     UNKNOWN_TOOL: (name: string) => `Unknown tool: ${name}`,
-
     UNKNOWN_ACTION: (tool: string, action: string) =>
       `Unknown ${tool} action: ${action}`,
   },

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -84,8 +84,6 @@ export function nullToUndefined<T>(obj: T, fields: (keyof T)[]): T {
 
 /**
  * Converts Buffer or string data to string, handling null/undefined values
- * @param data - Input data that may be string, Buffer, null, or undefined
- * @returns String representation or null
  */
 export function bufferToString(data?: string | Buffer | null): string | null {
   if (typeof data === 'string') return data;

--- a/src/validation/schemas.ts
+++ b/src/validation/schemas.ts
@@ -1,10 +1,3 @@
-/**
- * @fileoverview Comprehensive input validation schemas using Zod for security
- * @module validation/schemas
- * @description Security-focused validation with safe text patterns, URL validation,
- * and length limits to prevent injection attacks and malformed data
- */
-
 import { z } from 'zod/v3';
 import { VALIDATION } from '../utils/constants.js';
 

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "node_modules",
+    "dist",
+    "src/**/__mocks__/**",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/test-setup.ts"
+  ]
+}


### PR DESCRIPTION
## Summary

Fixes #83 by shipping a pre-built, signed, and notarized universal binary in the npm package so `npm install mcp-server-apple-events` just works with no Xcode required. Resolves TCC responsible-process attribution on OCLP Sequoia and macOS 26+ where Calendar permission dialogs were being suppressed.

- **Universal binary**: arm64 (macOS 11+) + x86_64 (macOS 10.15+) compiled separately and merged via `lipo`
- **Developer ID Application signing**: auto-detected from keychain with hardened runtime + entitlements for TCC subprocess attribution
- **Apple notarization**: submitted to notary service for Gatekeeper attribution; gracefully skipped for local dev without credentials
- **npm distribution**: `package.json` `files` field includes the pre-built binary; `postinstall` skips compilation when binary already exists
- **Release CI**: `.github/workflows/release.yml` automates build → sign → notarize → publish on `v*` tags

## Changes

| File | Change |
|---|---|
| `scripts/build-swift.mjs` | Compile arm64 + x86_64 separately, merge via `lipo` into universal binary |
| `scripts/notarize.mjs` | **New** — Submit signed binary to Apple notary service |
| `scripts/postinstall.mjs` | Skip build when pre-built binary already exists |
| `package.json` | Add `files` field; add `notarize` + `build:release` scripts |
| `src/utils/cliExecutor.ts` | Simplify error message for new npm install workflow |
| `src/swift/build-swift.test.ts` | Add 4 tests for universal binary compilation + cleanup |
| `src/swift/notarize.test.ts` | **New** — 6 tests for notarization workflow |
| `.github/workflows/release.yml` | **New** — Automated release pipeline with cert import + notarization |

## Required GitHub Secrets (for release workflow)

| Secret | Source |
|---|---|
| `APPLE_CERTIFICATE_BASE64` | `base64 -i cert.p12` from Keychain Access export |
| `APPLE_CERTIFICATE_PASSWORD` | Password set when exporting the .p12 |
| `APPLE_ID` | Apple ID email |
| `APPLE_APP_PASSWORD` | App-specific password from appleid.apple.com |
| `APPLE_TEAM_ID` | Team ID from Developer Portal |
| `NPM_TOKEN` | Automation token from npmjs.com |

## Test plan

- [x] `pnpm lint` — biome passes with no errors
- [x] `pnpm build` — produces universal binary (`lipo -info` confirms `x86_64 arm64`)
- [x] `codesign -dv bin/EventKitCLI` — shows `Developer ID Application: Xi Li (GTL29ANKNP)`
- [x] `pnpm test` — all 525 tests pass (including 11 new universal binary tests + 6 notarize tests)
- [x] `pnpm run notarize` without creds — exits 0 with warning (safe for local dev)
- [x] `node scripts/postinstall.mjs` with binary present — skips compilation
- [x] `npm pack --dry-run` — confirms `bin/EventKitCLI` included in package
- [ ] Verify release CI on first `v*` tag push
- [ ] Verify `npm install mcp-server-apple-events` on clean machine without Xcode (Intel + Apple Silicon)

## Breaking changes

None for users. The `postinstall` script now prefers a pre-built binary over compiling from source — users without Xcode who previously saw install failures will now succeed.