### PR TITLE
[codex] Scope calendar collections by date range

### DIFF
--- a/README.md
+++ b/README.md
@@ -681,19 +681,34 @@ Handles EventKit calendar events (time blocks) with CRUD capabilities.
 
 **Tool Name**: `calendar_calendars`
 
-Returns the available calendars from EventKit. This is useful before creating or updating events to confirm calendar identifiers.
+Returns the available calendars from EventKit. This is useful before creating or updating events to confirm calendar identifiers. Optional date range filters return only calendars that have events in the range and include event counts.
 
 **Actions**: `read`
 
+**Optional Parameters**:
+
+- `startDate`: Range start for scoped calendar discovery
+- `endDate`: Range end for scoped calendar discovery
+- `filterAccount`: Account name such as `"Google"` or `"Exchange"`
+
 **Main Handler Function**:
 
-- `handleReadCalendars()` - List all calendars with IDs and titles
+- `handleReadCalendars()` - List all calendars with IDs and titles, or scoped active calendars when a date range is supplied
 
 **Example Usage**
 
 ```json
 {
   "action": "read"
+}
+```
+
+```json
+{
+  "action": "read",
+  "startDate": "2026-05-04",
+  "endDate": "2026-05-11",
+  "filterAccount": "Google"
 }
 ```
 

--- a/src/tools/definitions.test.ts
+++ b/src/tools/definitions.test.ts
@@ -117,5 +117,16 @@ describe('Tools Definitions', () => {
       expect(startDateDescription).toContain('defaults to today');
       expect(endDateDescription).toContain('defaults to today + 14 days');
     });
+
+    it('should expose optional date range filters for calendar collections', () => {
+      const calendarsTool = TOOLS.find(
+        (tool) => tool.name === 'calendar_calendars',
+      );
+      const calendarProps = calendarsTool?.inputSchema.properties ?? {};
+
+      expect(calendarProps).toHaveProperty('startDate');
+      expect(calendarProps).toHaveProperty('endDate');
+      expect(calendarProps).toHaveProperty('filterAccount');
+    });
   });
 });

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -630,7 +630,7 @@ export const TOOLS: Tool[] = [
   {
     name: 'calendar_calendars',
     description:
-      'Reads calendar collections. Use to inspect available calendars before creating or updating events.',
+      'Reads calendar collections. Use to inspect available calendars before creating or updating events. Optional date range filters return only calendars with events in that range.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -638,6 +638,21 @@ export const TOOLS: Tool[] = [
           type: 'string',
           enum: ['read'],
           description: 'The operation to perform on calendars.',
+        },
+        startDate: {
+          type: 'string',
+          description:
+            "Optional range start for scoped calendar discovery. Format: 'YYYY-MM-DD', 'YYYY-MM-DD HH:mm:ss', or ISO 8601.",
+        },
+        endDate: {
+          type: 'string',
+          description:
+            'Optional range end for scoped calendar discovery. When used with startDate, only calendars with events in the range are returned.',
+        },
+        filterAccount: {
+          type: 'string',
+          description:
+            'Filter calendars by account name (e.g., "Google", "Exchange").',
         },
       },
       required: ['action'],

--- a/src/tools/handlers.test.ts
+++ b/src/tools/handlers.test.ts
@@ -671,7 +671,7 @@ describe('Tool Handlers', () => {
           accountType: 'caldav',
         },
       ];
-      mockCalendarRepository.findAllCalendars.mockResolvedValue(mockCalendars);
+      mockCalendarRepository.findCalendars.mockResolvedValue(mockCalendars);
       const result = await handleReadCalendars({ action: 'read' });
       const content = getTextContent(result.content);
       expect(content).toContain('### Calendars (Total: 2)');
@@ -680,11 +680,38 @@ describe('Tool Handlers', () => {
     });
 
     it('should support being called without args', async () => {
-      mockCalendarRepository.findAllCalendars.mockResolvedValue([]);
+      mockCalendarRepository.findCalendars.mockResolvedValue([]);
       const result = await handleReadCalendars();
       const content = getTextContent(result.content);
       expect(content).toContain('### Calendars (Total: 0)');
       expect(content).toContain('No calendars found.');
+    });
+
+    it('should support date-scoped calendar discovery', async () => {
+      mockCalendarRepository.findCalendars.mockResolvedValue([
+        {
+          id: 'cal-1',
+          title: 'Activity',
+          account: 'Google',
+          accountType: 'caldav',
+          eventCount: 7,
+        },
+      ]);
+
+      const result = await handleReadCalendars({
+        action: 'read',
+        startDate: '2026-05-04',
+        endDate: '2026-05-11',
+        filterAccount: 'Google',
+      });
+      const content = getTextContent(result.content);
+
+      expect(mockCalendarRepository.findCalendars).toHaveBeenCalledWith({
+        startDate: '2026-05-04',
+        endDate: '2026-05-11',
+        accountName: 'Google',
+      });
+      expect(content).toContain('- Activity (Google) (ID: cal-1) - 7 events');
     });
   });
 });

--- a/src/tools/handlers/calendarHandlers.ts
+++ b/src/tools/handlers/calendarHandlers.ts
@@ -193,13 +193,21 @@ export const handleReadCalendars = async (
   args?: CalendarsToolArgs,
 ): Promise<CallToolResult> => {
   return handleAsyncOperation(async () => {
-    extractAndValidateArgs(args, ReadCalendarsSchema);
-    const calendars = await calendarRepository.findAllCalendars();
+    const validatedArgs = extractAndValidateArgs(args, ReadCalendarsSchema);
+    const calendars = await calendarRepository.findCalendars({
+      startDate: validatedArgs.startDate,
+      endDate: validatedArgs.endDate,
+      accountName: validatedArgs.filterAccount,
+    });
     return formatListMarkdown(
       'Calendars',
       calendars,
       (calendar) => [
-        `- ${calendar.title} (${calendar.account}) (ID: ${calendar.id})`,
+        `- ${calendar.title} (${calendar.account}) (ID: ${calendar.id})${
+          calendar.eventCount !== undefined
+            ? ` - ${calendar.eventCount} event${calendar.eventCount === 1 ? '' : 's'}`
+            : ''
+        }`,
       ],
       'No calendars found.',
     );

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -185,6 +185,7 @@ export interface Calendar {
   title: string;
   account: string;
   accountType: string;
+  eventCount?: number;
 }
 
 /**
@@ -357,6 +358,9 @@ export interface CalendarToolArgs extends BaseToolArgs {
 
 export interface CalendarsToolArgs extends BaseToolArgs {
   action: CalendarsAction;
+  startDate?: string;
+  endDate?: string;
+  filterAccount?: string;
 }
 
 /**

--- a/src/utils/calendarRepository.test.ts
+++ b/src/utils/calendarRepository.test.ts
@@ -300,6 +300,81 @@ describe('CalendarRepository', () => {
     });
   });
 
+  describe('findCalendars', () => {
+    it('should return all calendars when no filters are provided', async () => {
+      const mockCalendars: Calendar[] = [
+        { id: '1', title: 'Work', account: 'Google', accountType: 'caldav' },
+      ];
+      mockExecuteCli.mockResolvedValue(mockCalendars);
+
+      const result = await repository.findCalendars({});
+
+      expect(mockExecuteCli).toHaveBeenCalledWith([
+        '--action',
+        'read-calendars',
+      ]);
+      expect(result).toEqual(mockCalendars);
+    });
+
+    it('should return calendars with events in a date range', async () => {
+      mockExecuteCli.mockResolvedValue({
+        calendars: [
+          { id: '1', title: 'Work', account: 'Google', accountType: 'caldav' },
+          {
+            id: '2',
+            title: 'Personal',
+            account: 'iCloud',
+            accountType: 'caldav',
+          },
+        ],
+        events: [
+          {
+            id: 'event-1',
+            title: 'Meeting',
+            calendar: 'Work',
+            startDate: '2026-05-04T09:00:00-05:00',
+            endDate: '2026-05-04T10:00:00-05:00',
+            isAllDay: false,
+          },
+          {
+            id: 'event-2',
+            title: 'Review',
+            calendar: 'Work',
+            startDate: '2026-05-05T09:00:00-05:00',
+            endDate: '2026-05-05T10:00:00-05:00',
+            isAllDay: false,
+          },
+        ],
+      });
+
+      const result = await repository.findCalendars({
+        startDate: '2026-05-04',
+        endDate: '2026-05-11',
+        accountName: 'Google',
+      });
+
+      expect(mockExecuteCli).toHaveBeenCalledWith([
+        '--action',
+        'read-events',
+        '--startDate',
+        '2026-05-04',
+        '--endDate',
+        '2026-05-11',
+        '--filterAccount',
+        'Google',
+      ]);
+      expect(result).toEqual([
+        {
+          id: '1',
+          title: 'Work',
+          account: 'Google',
+          accountType: 'caldav',
+          eventCount: 2,
+        },
+      ]);
+    });
+  });
+
   describe('findEvents with filterAccount', () => {
     afterEach(() => {
       jest.useRealTimers();

--- a/src/utils/calendarRepository.ts
+++ b/src/utils/calendarRepository.ts
@@ -178,6 +178,46 @@ class CalendarRepository {
     return executeCli<CalendarJSON[]>(['--action', 'read-calendars']);
   }
 
+  async findCalendars(filters: {
+    startDate?: string;
+    endDate?: string;
+    accountName?: string;
+  }): Promise<Calendar[]> {
+    if (!filters.startDate && !filters.endDate) {
+      const calendars = await this.findAllCalendars();
+      if (!filters.accountName) return calendars;
+      return calendars.filter(
+        (calendar) => calendar.account === filters.accountName,
+      );
+    }
+
+    const dateRange = resolveReadDateRange({
+      startDate: filters.startDate,
+      endDate: filters.endDate,
+    });
+    const { calendars, events } = await this.readEvents(
+      dateRange.startDate,
+      dateRange.endDate,
+      undefined,
+      undefined,
+      filters.accountName,
+    );
+    const eventCountByTitle = new Map<string, number>();
+    for (const event of events) {
+      eventCountByTitle.set(
+        event.calendar,
+        (eventCountByTitle.get(event.calendar) ?? 0) + 1,
+      );
+    }
+
+    return calendars
+      .filter((calendar) => eventCountByTitle.has(calendar.title))
+      .map((calendar) => ({
+        ...calendar,
+        eventCount: eventCountByTitle.get(calendar.title) ?? 0,
+      }));
+  }
+
   async createEvent(data: CreateEventData): Promise<EventJSON> {
     const args = [
       '--action',

--- a/src/validation/schemas.ts
+++ b/src/validation/schemas.ts
@@ -541,7 +541,11 @@ export const DeleteCalendarEventSchema = z.object({
   span: SpanSchema,
 });
 
-export const ReadCalendarsSchema = z.object({});
+export const ReadCalendarsSchema = z.object({
+  startDate: SafeDateSchema,
+  endDate: SafeDateSchema,
+  filterAccount: SafeListNameSchema,
+});
 
 export const CreateReminderListSchema = z.object({
   name: RequiredListNameSchema,


### PR DESCRIPTION
## Summary

Adds date-scoped discovery to the `calendar_calendars` MCP tool.

## What changed

- Adds optional `startDate`, `endDate`, and `filterAccount` parameters to `calendar_calendars`.
- Preserves existing all-calendars behavior when no date range is supplied.
- When a date range is supplied, returns only calendars with events in that range and includes per-calendar event counts.
- Documents the scoped calendar discovery payload and adds repository/handler/schema tests.

## Why

Agents often only need to know which calendars are active in a bounded planning window before reading events. This avoids broad calendar discovery being used as a proxy for time-scoped event context.

## Validation

- `pnpm exec biome check README.md src/tools/definitions.ts src/tools/definitions.test.ts src/tools/handlers.test.ts src/tools/handlers/calendarHandlers.ts src/types/index.ts src/utils/calendarRepository.ts src/utils/calendarRepository.test.ts src/validation/schemas.ts`
- `pnpm jest src/tools/handlers.test.ts src/utils/calendarRepository.test.ts src/tools/definitions.test.ts --runInBand`
- `pnpm exec tsc --noEmit --project tsconfig.json`
