### PR TITLE
fix(swift): detect macOS 26 SDK vs Swift toolchain mismatch in build script (closes #85)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,30 @@ pnpm test -- src/swift/Info.plist.test.ts
 
 The test suite ensures all required usage-description strings are present before shipping the binary.
 
+### Troubleshooting `could not build module 'Foundation'` on macOS 26 (Tahoe)
+
+If `pnpm build` fails with `could not build module 'Foundation'` (or `SDK is not supported by the compiler`), your Swift toolchain is older than the macOS 26 SDK requires. The macOS 26+ SDK ships a `Foundation.swiftinterface` that needs **Swift 6.3 or newer**; the Command Line Tools that shipped with the first macOS 26 point releases include Swift 6.2.x, which cannot parse it. See [issue #85](https://github.com/FradSer/mcp-server-apple-events/issues/85).
+
+`pnpm build:swift` now detects this mismatch and prints the same remediation, but if you hit it manually:
+
+1. Install Xcode 26.x from the App Store (ships Swift 6.3+), or
+2. Update Command Line Tools to a version that ships Swift 6.3+:
+   ```bash
+   softwareupdate --list
+   sudo softwareupdate -i "Command Line Tools for Xcode-<latest>"
+   ```
+3. If both are installed, point `xcode-select` at the full Xcode:
+   ```bash
+   sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer
+   ```
+
+Verify with:
+
+```bash
+xcrun swiftc --version          # should report Apple Swift version 6.3 or newer
+xcrun --show-sdk-version        # should match your macOS major version
+```
+
 ## Quick Start
 
 You can run the server directly using `npx`:

--- a/scripts/build-swift.mjs
+++ b/scripts/build-swift.mjs
@@ -6,6 +6,91 @@ import { promisify } from 'node:util';
 
 const execAsync = promisify(exec);
 
+// macOS 26+ SDKs ship a Foundation.swiftinterface that older swiftc cannot parse,
+// surfacing as `could not build module 'Foundation'` / `SDK is not supported by
+// the compiler`. See: https://github.com/FradSer/mcp-server-apple-events/issues/85
+const MIN_SWIFT_MAJOR_FOR_MACOS_26 = 6;
+const MIN_SWIFT_MINOR_FOR_MACOS_26 = 3;
+
+async function getSwiftVersion() {
+  try {
+    const { stdout } = await execAsync('xcrun swiftc --version');
+    const match = stdout.match(/Apple Swift version (\d+)\.(\d+)(?:\.(\d+))?/);
+    if (!match) return null;
+    return {
+      major: Number.parseInt(match[1], 10),
+      minor: Number.parseInt(match[2], 10),
+      patch: match[3] ? Number.parseInt(match[3], 10) : 0,
+      raw: match[0].replace(/^Apple Swift version /, ''),
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function getSdkVersion() {
+  try {
+    const { stdout } = await execAsync('xcrun --show-sdk-version');
+    const trimmed = stdout.trim();
+    const [maj, min] = trimmed.split('.');
+    return {
+      major: Number.parseInt(maj, 10),
+      minor: Number.parseInt(min ?? '0', 10),
+      raw: trimmed,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function isSdkTooNewForSwift(swift, sdk) {
+  if (!swift || !sdk) return false;
+  if (sdk.major < 26) return false;
+  if (swift.major > MIN_SWIFT_MAJOR_FOR_MACOS_26) return false;
+  if (swift.major < MIN_SWIFT_MAJOR_FOR_MACOS_26) return true;
+  return swift.minor < MIN_SWIFT_MINOR_FOR_MACOS_26;
+}
+
+function printIncompatibilityRemediation(swift, sdk) {
+  const swiftStr = swift ? swift.raw : 'unknown';
+  const sdkStr = sdk ? sdk.raw : 'unknown';
+  console.error(
+    [
+      '',
+      `Error: Swift toolchain ${swiftStr} cannot build against the macOS ${sdkStr} SDK.`,
+      `The macOS 26+ SDK requires Swift ${MIN_SWIFT_MAJOR_FOR_MACOS_26}.${MIN_SWIFT_MINOR_FOR_MACOS_26} or newer; older swiftc fails with`,
+      `"could not build module 'Foundation'" because the SDK's Foundation.swiftinterface`,
+      'uses availability markers older compilers do not understand.',
+      '',
+      'See: https://github.com/FradSer/mcp-server-apple-events/issues/85',
+      '',
+      'Fixes (pick one):',
+      '  1. Install Xcode 26.x from the App Store (ships Swift 6.3+).',
+      '  2. Update Command Line Tools to a version that ships Swift 6.3+:',
+      '       softwareupdate --list',
+      '       sudo softwareupdate -i "Command Line Tools for Xcode-<latest>"',
+      '  3. If both Xcode and Command Line Tools are installed, point xcode-select',
+      '     at the full Xcode that has the matching toolchain:',
+      '       sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer',
+      '',
+    ].join('\n'),
+  );
+}
+
+function looksLikeFoundationModuleMismatch(stderr) {
+  if (!stderr) return false;
+  return (
+    /could not build module 'Foundation'/.test(stderr) ||
+    /SDK is not supported by the compiler/.test(stderr) ||
+    /module compiled with Swift [\d.]+ cannot be imported/.test(stderr)
+  );
+}
+
+function swiftArchForHost() {
+  // Swift target triples use `arm64` and `x86_64`; Node reports `arm64` and `x64`.
+  return process.arch === 'arm64' ? 'arm64' : 'x86_64';
+}
+
 async function main() {
   console.log('Building Swift binary for Apple Reminders MCP Server...');
 
@@ -17,12 +102,19 @@ async function main() {
   }
 
   try {
-    await execAsync('which swiftc');
+    await execAsync('xcrun --find swiftc');
   } catch (_error) {
-    console.error('Error: Swift compiler (swiftc) not found.');
+    console.error('Error: Swift compiler (swiftc) not found via xcrun.');
     console.error(
       'Please install Xcode or Xcode Command Line Tools: xcode-select --install',
     );
+    process.exit(1);
+  }
+
+  const swift = await getSwiftVersion();
+  const sdk = await getSdkVersion();
+  if (isSdkTooNewForSwift(swift, sdk)) {
+    printIncompatibilityRemediation(swift, sdk);
     process.exit(1);
   }
 
@@ -66,11 +158,18 @@ async function main() {
 
   await fs.mkdir(binDir, { recursive: true });
 
+  // Pin deployment target to macOS 13.0 — the lowest the Swift source supports
+  // via its `requestAccess(to: .reminder)` legacy branch. Pinning keeps the
+  // build deterministic across SDK versions and avoids defaulting to the host
+  // SDK's target, which on macOS 26 makes the macOS-14 fallback path appear
+  // unreachable. Use `xcrun -sdk macosx swiftc` so the toolchain and SDK that
+  // `xcode-select` resolves are used consistently.
+  const target = `${swiftArchForHost()}-apple-macosx13.0`;
   // Use -Xlinker to embed Info.plist into the binary
   // This is required for macOS to show permission dialogs for EventKit access
-  const compileCommand = `swiftc -o "${outputFile}" "${sourceFile}" -framework EventKit -framework Foundation -Xlinker -sectcreate -Xlinker __TEXT -Xlinker __info_plist -Xlinker "${infoPlistFile}"`;
+  const compileCommand = `xcrun -sdk macosx swiftc -target ${target} -o "${outputFile}" "${sourceFile}" -framework EventKit -framework Foundation -Xlinker -sectcreate -Xlinker __TEXT -Xlinker __info_plist -Xlinker "${infoPlistFile}"`;
 
-  console.log(`Compiling ${sourceFile}...`);
+  console.log(`Compiling ${sourceFile} (target ${target})...`);
 
   try {
     const { stdout, stderr } = await execAsync(compileCommand);
@@ -101,6 +200,10 @@ async function main() {
     console.log('Swift binary build complete!');
   } catch (error) {
     console.error('Compilation failed!');
+    const stderr = error?.stderr ?? '';
+    if (looksLikeFoundationModuleMismatch(stderr)) {
+      printIncompatibilityRemediation(swift, sdk);
+    }
     console.error(error);
     process.exit(1);
   }

--- a/src/swift/build-swift.test.ts
+++ b/src/swift/build-swift.test.ts
@@ -18,3 +18,44 @@ describe('build-swift.mjs code signing', () => {
     expect(buildScript).toMatch(/codesign.*--entitlements/);
   });
 });
+
+describe('build-swift.mjs toolchain resolution', () => {
+  const buildScript = readFileSync(buildScriptPath, 'utf8');
+
+  it('invokes swiftc via xcrun so SDK and toolchain stay consistent', () => {
+    expect(buildScript).toMatch(/xcrun\s+(?:-sdk\s+macosx\s+)?swiftc/);
+  });
+
+  it('pins -target to macosx13.0 (lowest supported deployment)', () => {
+    // Target triple may be built via a variable; just assert both the flag and
+    // the deployment string are present in the script.
+    expect(buildScript).toMatch(/-target/);
+    expect(buildScript).toMatch(/apple-macosx13\.0/);
+  });
+
+  it('derives swift target arch from the host (process.arch)', () => {
+    expect(buildScript).toMatch(/process\.arch/);
+  });
+});
+
+describe('build-swift.mjs toolchain/SDK compatibility (issue #85)', () => {
+  const buildScript = readFileSync(buildScriptPath, 'utf8');
+
+  it('detects Swift toolchain older than macOS 26 SDK requires before compile', () => {
+    // Pre-flight check must parse swiftc version and compare against SDK major.
+    expect(buildScript).toMatch(/Apple Swift version/);
+    expect(buildScript).toMatch(/--show-sdk-version/);
+  });
+
+  it('surfaces actionable remediation when SDK is too new for the toolchain', () => {
+    // Error message must mention the path to fix (xcode-select / Xcode / CLT) and link to issue #85.
+    expect(buildScript).toMatch(/issues\/85/);
+    expect(buildScript).toMatch(/xcode-select|Xcode|Command Line Tools/);
+  });
+
+  it('augments compile-failure output when stderr matches known Foundation incompat patterns', () => {
+    expect(buildScript).toMatch(
+      /could not build module 'Foundation'|SDK is not supported by the compiler/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Issue #85 reports `pnpm build` failing with `could not build module 'Foundation'` on macOS 26.3 (Tahoe) + Command Line Tools 26.3 (Swift 6.2.4). The root cause is a Swift toolchain / SDK version mismatch: the macOS 26+ SDK ships a `Foundation.swiftinterface` that requires **Swift 6.3 or newer** to parse, while CLT 26.3 still ships Swift 6.2.x. No swiftc flag can compile a too-new SDK with an older toolchain — the user must update their toolchain. This PR makes the build script detect that case cleanly and surface an actionable fix instead of the cryptic raw compiler error.

Cross-references: [swiftlang/swift#84379](https://github.com/swiftlang/swift/issues/84379), [Swift forums thread](https://forums.swift.org/t/unable-to-build-swift-main-toolchain-locally-after-installing-xcode-26/80394).

## Changes

`scripts/build-swift.mjs`:

- Invoke `swiftc` via `xcrun` so the toolchain and SDK `xcode-select` resolves stay consistent.
- Pre-flight: parse `xcrun swiftc --version` and `xcrun --show-sdk-version`. If SDK major ≥ 26 and Swift < 6.3, refuse to compile with a clear remediation block.
- Augment the compile-failure path: if `stderr` matches the known incompat patterns (`could not build module 'Foundation'`, `SDK is not supported by the compiler`, `module compiled with Swift … cannot be imported`), print the same remediation. Belt-and-suspenders in case the pre-flight detection misses an edge case.
- Pin `-target <host-arch>-apple-macosx13.0` — the lowest the Swift source supports via its `requestAccess(to: .reminder)` legacy branch. Side benefit: silences the two `unnecessary check for 'macOS'` warnings the previous build emitted on macOS 26, since the macOS-14 fallback path is now reachable again.

`src/swift/build-swift.test.ts`:

- Adds 6 new tests for the behaviors above (xcrun invocation, target pin, host-arch derivation, pre-flight version check, remediation message presence, compile-failure stderr augmentation).

`README.md`:

- New `Troubleshooting could not build module 'Foundation' on macOS 26 (Tahoe)` section under the existing Troubleshooting block, with the same three remediation paths the build script prints.

## Verification

- `pnpm test` — 517 / 517 pass (including 9 / 9 in `build-swift.test.ts`).
- `pnpm lint` — clean.
- `pnpm build` — end-to-end build green on macOS 26.5 / Xcode 26.5 / Swift 6.3.2; the previous "unnecessary availability check" warnings are gone after the target pin. Resulting `bin/EventKitCLI` is Mach-O arm64 and answers `--action read` successfully.
- Detection logic verified against a case matrix (issue #85 reporter's `swift 6.2.4 + sdk 26.3` → flagged; this Mac's `6.3.2 + 26.5` → pass-through; older Swift on macOS 15 → pass-through; future Swift 7 → pass-through; detection-unknown → pass-through).

I could not reproduce the original failure locally because this Mac already has Swift 6.3.2. The pre-flight check is the most reliable layer; the stderr-pattern augmentation is a fallback for toolchain combinations the pre-flight predicate doesn't model.

Closes #85.

🤖 Generated with [Claude Code](https://claude.com/claude-code)