### PR TITLE
fix(pkg): add npm files allowlist to drop dev-only files from tarball

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,17 @@
   "bin": {
     "mcp-server-apple-events": "./bin/run.cjs"
   },
+  "files": [
+    "bin/run.cjs",
+    "dist",
+    "scripts/postinstall.mjs",
+    "scripts/build-swift.mjs",
+    "src/swift/EventKitCLI.swift",
+    "src/swift/EventKitCLI.entitlements",
+    "src/swift/Info.plist",
+    "CHANGELOG.md",
+    "README.zh-CN.md"
+  ],
   "scripts": {
     "clean": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\"",
     "build:ts": "tsc -p tsconfig.json",


### PR DESCRIPTION
## Summary

Adds an explicit `files` allowlist to `package.json` so the published npm tarball ships only runtime artifacts. Resolves the issue surfaced in #95 where `CLAUDE.md` (and a pile of other maintainer-only files) were being published to npm and the npx cache.

## Why

Before this change, `npm pack` fell back to `.gitignore` and pulled in every non-ignored file at the repo root — including `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, `.claude/git.local.md`, `.git-agent/config.yml`, `biome.json`, `check-permissions.sh`, and the entire `vendor/event/` tree (including `vendor/event/CLAUDE.md`). None of these are needed at runtime. As [#95](https://github.com/FradSer/mcp-server-apple-events/issues/95) notes, the most acute side effect is that Claude Code can auto-load `CLAUDE.md` files from any directory it tool-touches, so downstream developers using Claude Code against an npx-cached copy of this package could end up with the maintainer's project guide injected into their session context.

## What changed

`package.json` now lists exactly the files consumers need:

- `bin/run.cjs` — the bin entrypoint
- `dist` — the compiled TypeScript output (`main`)
- `scripts/postinstall.mjs` — runs on install
- `scripts/build-swift.mjs` — invoked by postinstall
- `src/swift/EventKitCLI.swift`, `src/swift/Info.plist`, `src/swift/EventKitCLI.entitlements` — sources the postinstall build needs
- `CHANGELOG.md`, `README.zh-CN.md` — user-facing docs (`README.md`, `LICENSE`, `package.json` are always auto-included by npm)

## Verification

`npm pack --dry-run` before vs after:

| | Before | After |
|---|---:|---:|
| Package size | 987.1 kB | 211.8 kB |
| Unpacked size | 4.1 MB | 1.1 MB |
| Total files | 347 | 197 |
| `CLAUDE.md` shipped? | yes | **no** |
| `vendor/event/CLAUDE.md` shipped? | yes | **no** |
| `bin/run.cjs` shipped? | yes | yes |
| `scripts/postinstall.mjs` + `scripts/build-swift.mjs` shipped? | yes | yes |
| `src/swift/EventKitCLI.swift` + `Info.plist` + `.entitlements` shipped? | yes | yes |

`pnpm lint` (Biome + `tsc --noEmit`) passes.

## Out of scope

`tsc` still emits test JS into `dist/` (`dist/**/*.test.js`), so those still ship. Narrowing the build to non-test sources would require a separate `tsconfig.build.json` — happy to follow up in another PR if useful.

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)