### PR TITLE
fix: reject malformed date inputs

### DIFF
--- a/src/swift/EventKitCLI.dateValidation.test.ts
+++ b/src/swift/EventKitCLI.dateValidation.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const swiftPath = path.resolve(process.cwd(), 'src/swift/EventKitCLI.swift');
+const swiftSource = readFileSync(swiftPath, 'utf8');
+
+describe('EventKitCLI date validation safeguards', () => {
+  it('rejects malformed read-events date bounds before EventKit receives nil bounds', () => {
+    expect(swiftSource).toContain('Invalid startDate format.');
+    expect(swiftSource).toContain('Invalid endDate format.');
+    expect(swiftSource).toMatch(
+      /let startDate = startDateStr != nil \? manager\.parseDate\(from: startDateStr!\) : nil[\s\S]*?Invalid startDate format\./,
+    );
+    expect(swiftSource).toMatch(
+      /let endDate = endDateStr != nil \? manager\.parseDate\(from: endDateStr!\) : nil[\s\S]*?Invalid endDate format\./,
+    );
+  });
+});

--- a/src/swift/EventKitCLI.swift
+++ b/src/swift/EventKitCLI.swift
@@ -1771,6 +1771,12 @@ func main() {
                 let endDateStr = parser.get("endDate")
                 let startDate = startDateStr != nil ? manager.parseDate(from: startDateStr!) : nil
                 let endDate = endDateStr != nil ? manager.parseDate(from: endDateStr!) : nil
+                if startDateStr != nil && startDate == nil {
+                    throw NSError(domain: "", code: 400, userInfo: [NSLocalizedDescriptionKey: "Invalid startDate format."])
+                }
+                if endDateStr != nil && endDate == nil {
+                    throw NSError(domain: "", code: 400, userInfo: [NSLocalizedDescriptionKey: "Invalid endDate format."])
+                }
                 let events = try manager.getEvents(startDate: startDate, endDate: endDate, calendarName: parser.get("filterCalendar"), search: parser.get("search"), availability: parser.get("availability"), accountName: parser.get("filterAccount"))
                 print(String(data: try encoder.encode(StandardOutput(result: EventsReadResult(calendars: manager.getCalendars(), events: events))), encoding: .utf8)!)
             case "read-calendars":

--- a/src/utils/calendarRepository.test.ts
+++ b/src/utils/calendarRepository.test.ts
@@ -208,6 +208,13 @@ describe('CalendarRepository', () => {
       ]);
     });
 
+    it('rejects invalid date bounds instead of issuing an unbounded CLI read', async () => {
+      await expect(
+        repository.findEvents({ startDate: 'not-a-date' }),
+      ).rejects.toThrow('startDate must be a valid date');
+      expect(mockExecuteCli).not.toHaveBeenCalled();
+    });
+
     it('should filter events by calendar name', async () => {
       const mockEvents: Partial<CalendarEvent>[] = [
         {

--- a/src/utils/calendarRepository.ts
+++ b/src/utils/calendarRepository.ts
@@ -51,9 +51,7 @@ const parseDateInput = (value: string): Date | undefined => {
 const requireParsedDateInput = (value: string, fieldName: string): Date => {
   const parsed = parseDateInput(value);
   if (!parsed) {
-    throw new Error(
-      `${fieldName} must be a valid date before reading calendar events.`,
-    );
+    throw new Error(`${fieldName} must be a valid date`);
   }
   return parsed;
 };

--- a/src/utils/calendarRepository.ts
+++ b/src/utils/calendarRepository.ts
@@ -48,6 +48,16 @@ const parseDateInput = (value: string): Date | undefined => {
   return Number.isNaN(parsed.getTime()) ? undefined : parsed;
 };
 
+const requireParsedDateInput = (value: string, fieldName: string): Date => {
+  const parsed = parseDateInput(value);
+  if (!parsed) {
+    throw new Error(
+      `${fieldName} must be a valid date before reading calendar events.`,
+    );
+  }
+  return parsed;
+};
+
 const shiftDays = (date: Date, days: number): Date => {
   const shifted = new Date(date);
   shifted.setDate(shifted.getDate() + days);
@@ -59,6 +69,8 @@ const resolveReadDateRange = (filters: {
   endDate?: string;
 }): { startDate?: string; endDate?: string } => {
   if (filters.startDate && filters.endDate) {
+    requireParsedDateInput(filters.startDate, 'startDate');
+    requireParsedDateInput(filters.endDate, 'endDate');
     return { startDate: filters.startDate, endDate: filters.endDate };
   }
 
@@ -71,8 +83,7 @@ const resolveReadDateRange = (filters: {
   }
 
   if (filters.startDate && !filters.endDate) {
-    const start = parseDateInput(filters.startDate);
-    if (!start) return { startDate: filters.startDate };
+    const start = requireParsedDateInput(filters.startDate, 'startDate');
     return {
       startDate: filters.startDate,
       endDate: formatDateOnly(shiftDays(start, DEFAULT_READ_WINDOW_DAYS)),
@@ -80,8 +91,7 @@ const resolveReadDateRange = (filters: {
   }
 
   if (!filters.startDate && filters.endDate) {
-    const end = parseDateInput(filters.endDate);
-    if (!end) return { endDate: filters.endDate };
+    const end = requireParsedDateInput(filters.endDate, 'endDate');
     return {
       startDate: formatDateOnly(shiftDays(end, -DEFAULT_READ_WINDOW_DAYS)),
       endDate: filters.endDate,

--- a/src/validation/schemas.test.ts
+++ b/src/validation/schemas.test.ts
@@ -168,6 +168,22 @@ describe('ValidationSchemas', () => {
         expect(() => SafeDateSchema.parse('0005-01-01')).not.toThrow();
       });
 
+      it('should accept Feb 29 in leap years', () => {
+        // Regression: an earlier implementation seeded the validity check
+        // from year 0 (mapped to 1900, a non-leap year), so every Feb 29
+        // overflowed to Mar 1 and was rejected even for real leap years.
+        expect(() => SafeDateSchema.parse('2024-02-29')).not.toThrow();
+        expect(() => SafeDateSchema.parse('2000-02-29')).not.toThrow();
+        expect(() => SafeDateSchema.parse('2028-02-29')).not.toThrow();
+        expect(() => SafeDateSchema.parse('2024-02-29 23:59:59')).not.toThrow();
+      });
+
+      it('should reject Feb 29 in non-leap years', () => {
+        expect(() => SafeDateSchema.parse('2023-02-29')).toThrow();
+        expect(() => SafeDateSchema.parse('1900-02-29')).toThrow();
+        expect(() => SafeDateSchema.parse('2100-02-29')).toThrow();
+      });
+
       it('should accept undefined dates', () => {
         expect(() => SafeDateSchema.parse(undefined)).not.toThrow();
       });
@@ -177,6 +193,8 @@ describe('ValidationSchemas', () => {
         expect(() => SafeDateSchema.parse('not-a-date')).toThrow();
         expect(() => SafeDateSchema.parse('2024-13-45')).toThrow();
         expect(() => SafeDateSchema.parse('2024-02-30')).toThrow();
+        expect(() => SafeDateSchema.parse('2024-00-15')).toThrow();
+        expect(() => SafeDateSchema.parse('2024-01-00')).toThrow();
         expect(() => SafeDateSchema.parse('2024-01-15oops')).toThrow();
         expect(() => SafeDateSchema.parse('2024-01-15 25:00:00')).toThrow();
       });

--- a/src/validation/schemas.test.ts
+++ b/src/validation/schemas.test.ts
@@ -174,8 +174,10 @@ describe('ValidationSchemas', () => {
       it('should reject invalid date formats', () => {
         expect(() => SafeDateSchema.parse('01/15/2024')).toThrow();
         expect(() => SafeDateSchema.parse('not-a-date')).toThrow();
-        // Note: DATE_PATTERN only checks basic format, doesn't validate date ranges
-        expect(() => SafeDateSchema.parse('2024-13-45')).not.toThrow();
+        expect(() => SafeDateSchema.parse('2024-13-45')).toThrow();
+        expect(() => SafeDateSchema.parse('2024-02-30')).toThrow();
+        expect(() => SafeDateSchema.parse('2024-01-15oops')).toThrow();
+        expect(() => SafeDateSchema.parse('2024-01-15 25:00:00')).toThrow();
       });
     });
 

--- a/src/validation/schemas.test.ts
+++ b/src/validation/schemas.test.ts
@@ -165,6 +165,7 @@ describe('ValidationSchemas', () => {
         expect(() =>
           SafeDateSchema.parse('2024-01-15T10:30:00Z'),
         ).not.toThrow();
+        expect(() => SafeDateSchema.parse('0005-01-01')).not.toThrow();
       });
 
       it('should accept undefined dates', () => {

--- a/src/validation/schemas.ts
+++ b/src/validation/schemas.ts
@@ -210,6 +210,15 @@ function createSafeTextSchema(
   return optional ? schema.optional() : schema;
 }
 
+// Days per month (1-indexed via month - 1). February is treated as 28; leap
+// years are accounted for explicitly below so we don't have to round-trip
+// through `Date`, which has surprising behavior for years 0-99 (mapped to
+// 1900-1999) and for Feb 29 seeded from a non-leap year.
+const DAYS_IN_MONTH = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+
+const isLeapYear = (year: number): boolean =>
+  (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+
 function isValidDateInput(value: string): boolean {
   const match = DATE_PATTERN.exec(value);
   if (!match) return false;
@@ -221,17 +230,13 @@ function isValidDateInput(value: string): boolean {
   const minute = match[5] === undefined ? 0 : Number(match[5]);
   const second = match[6] === undefined ? 0 : Number(match[6]);
 
+  if (month < 1 || month > 12) return false;
   if (hour > 23 || minute > 59 || second > 59) return false;
 
-  const date = new Date(Date.UTC(0, month - 1, day));
-  date.setUTCFullYear(year);
-  if (
-    date.getUTCFullYear() !== year ||
-    date.getUTCMonth() !== month - 1 ||
-    date.getUTCDate() !== day
-  ) {
-    return false;
-  }
+  const monthDays = DAYS_IN_MONTH[month - 1];
+  if (monthDays === undefined) return false; // unreachable: month is 1-12
+  const maxDay = month === 2 && isLeapYear(year) ? 29 : monthDays;
+  if (day < 1 || day > maxDay) return false;
 
   const normalized = value.includes(' ') ? value.replace(' ', 'T') : value;
   return !Number.isNaN(new Date(normalized).getTime());

--- a/src/validation/schemas.ts
+++ b/src/validation/schemas.ts
@@ -223,7 +223,8 @@ function isValidDateInput(value: string): boolean {
 
   if (hour > 23 || minute > 59 || second > 59) return false;
 
-  const date = new Date(Date.UTC(year, month - 1, day));
+  const date = new Date(Date.UTC(0, month - 1, day));
+  date.setUTCFullYear(year);
   if (
     date.getUTCFullYear() !== year ||
     date.getUTCMonth() !== month - 1 ||

--- a/src/validation/schemas.ts
+++ b/src/validation/schemas.ts
@@ -15,9 +15,11 @@ import { VALIDATION } from '../utils/constants.js';
 // This keeps Chinese/Unicode names working while remaining safe with AppleScript quoting.
 const SAFE_TEXT_PATTERN =
   /^[\u0020-\u007E\u00A0-\u2027\u202F-\u2065\u206A-\uD7FF\uE000-\u{10FFFF}\n\r\t]*$/u;
-// Support multiple date formats: YYYY-MM-DD, YYYY-MM-DD HH:mm:ss, or ISO 8601
-// Basic validation - detailed parsing handled by Swift
-const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}.*$/;
+// Support multiple date formats: YYYY-MM-DD, YYYY-MM-DD HH:mm:ss, or ISO 8601.
+// Keep this strict enough that a malformed date cannot pass the TS layer and
+// later collapse to an unbounded EventKit query in the Swift CLI.
+const DATE_PATTERN =
+  /^(\d{4})-(\d{2})-(\d{2})(?:[ T](\d{2}):(\d{2})(?::(\d{2}))?(?:\.\d{1,9})?(?:Z|[+-]\d{2}:?\d{2})?)?$/;
 // URL validation that blocks internal/private network addresses and localhost
 // Prevents SSRF attacks while allowing legitimate external URLs
 // Blocks: IPv4 private/reserved (127.x, 192.168.x, 10.x, 172.16-31.x, 169.254.x, 0.0.0.0, 224-239.x multicast)
@@ -208,6 +210,32 @@ function createSafeTextSchema(
   return optional ? schema.optional() : schema;
 }
 
+function isValidDateInput(value: string): boolean {
+  const match = DATE_PATTERN.exec(value);
+  if (!match) return false;
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const hour = match[4] === undefined ? 0 : Number(match[4]);
+  const minute = match[5] === undefined ? 0 : Number(match[5]);
+  const second = match[6] === undefined ? 0 : Number(match[6]);
+
+  if (hour > 23 || minute > 59 || second > 59) return false;
+
+  const date = new Date(Date.UTC(year, month - 1, day));
+  if (
+    date.getUTCFullYear() !== year ||
+    date.getUTCMonth() !== month - 1 ||
+    date.getUTCDate() !== day
+  ) {
+    return false;
+  }
+
+  const normalized = value.includes(' ') ? value.replace(' ', 'T') : value;
+  return !Number.isNaN(new Date(normalized).getTime());
+}
+
 /**
  * Base validation schemas using factory functions
  */
@@ -256,6 +284,7 @@ export const SafeDateSchema = z
     DATE_PATTERN,
     "Date must be in format 'YYYY-MM-DD', 'YYYY-MM-DD HH:mm:ss', or ISO 8601 (e.g., '2025-10-30T04:00:00Z')",
   )
+  .refine(isValidDateInput, 'Date must be a real, parseable date/time')
   .optional();
 
 /**
@@ -264,11 +293,15 @@ export const SafeDateSchema = z
 const createRequiredDateSchema = (fieldName: string) =>
   z
     .string()
+    .min(1, `${fieldName} is required`)
     .regex(
       DATE_PATTERN,
       `${fieldName} must be in format 'YYYY-MM-DD', 'YYYY-MM-DD HH:mm:ss', or ISO 8601`,
     )
-    .min(1, `${fieldName} is required`);
+    .refine(
+      isValidDateInput,
+      `${fieldName} must be a real, parseable date/time`,
+    );
 
 export const SafeUrlSchema = z
   .string()


### PR DESCRIPTION
## Summary
- tighten accepted date formats for reminder and calendar inputs
- reject invalid calendar read bounds before invoking EventKit
- make the Swift read-events action fail on malformed start/end dates instead of passing nil bounds

## Tests
- pnpm exec biome check .
- pnpm exec tsc --noEmit --project tsconfig.json
- pnpm test -- validation/schemas.test.ts utils/calendarRepository.test.ts swift/EventKitCLI.dateValidation.test.ts