### PR TITLE
fix: support Unicode (CJK / non-Latin) tags in regex and validation

### DIFF
--- a/src/utils/tagUtils.test.ts
+++ b/src/utils/tagUtils.test.ts
@@ -70,6 +70,29 @@ describe('tagUtils', () => {
     it('extracts digit-starting mixed tags like #1st', () => {
       expect(extractTags('#1st #2024q1 notes')).toEqual(['1st', '2024q1']);
     });
+
+    it('extracts CJK bare tags (Chinese / Japanese / Korean)', () => {
+      expect(extractTags('#雷蒙三十 #日本語 #한국어 notes')).toEqual([
+        '雷蒙三十',
+        '日本語',
+        '한국어',
+      ]);
+    });
+
+    it('extracts mixed CJK + ASCII tags', () => {
+      expect(extractTags('#中文_english #2024年 notes')).toEqual([
+        '中文_english',
+        '2024年',
+      ]);
+    });
+
+    it('stops CJK tags at CJK punctuation', () => {
+      expect(extractTags('#雷蒙，notes here')).toEqual(['雷蒙']);
+    });
+
+    it('extracts space-separated CJK tags after CJK punctuation', () => {
+      expect(extractTags('#雷蒙， #柚子。 done')).toEqual(['雷蒙', '柚子']);
+    });
   });
 
   describe('stripTags', () => {
@@ -79,6 +102,10 @@ describe('tagUtils', () => {
 
     it('strips bare #tag format', () => {
       expect(stripTags('#social #work Some notes')).toBe('Some notes');
+    });
+
+    it('strips CJK bare tags', () => {
+      expect(stripTags('#雷蒙三十 #日本語 Some notes')).toBe('Some notes');
     });
 
     it('strips mixed formats', () => {

--- a/src/utils/tagUtils.ts
+++ b/src/utils/tagUtils.ts
@@ -16,8 +16,14 @@ const BRACKET_TAG_REGEX = /\[#([^\]]+)\]/g;
 // Regex to match bare #tag format (Apple Reminders native).
 // Must be preceded by start-of-string or whitespace.
 // Uses negative lookahead to exclude purely numeric tags (e.g. #42)
-// while allowing digit-starting mixed tags (e.g. #1st, #2024q1).
-const BARE_TAG_REGEX = /(?:^|(?<=\s))#(?![0-9]+\b)([a-zA-Z0-9_-]+)/gm;
+// while allowing digit-starting mixed tags (e.g. #1st, #2024q1, #2024年).
+// Body uses Unicode property classes so CJK / Japanese / Korean / other
+// non-Latin scripts work as tag characters (e.g. #雷蒙三十, #日本語, #한국어).
+// The inner negative lookahead `(?![\p{L}\p{N}_-])` replaces the old `\b`,
+// which broke for CJK because `\b` fires between ASCII digits and CJK letters
+// (CJK chars count as `\W` in JS regex), causing `#2024年` to be rejected.
+const BARE_TAG_REGEX =
+  /(?:^|(?<=\s))#(?![0-9]+(?![\p{L}\p{N}_-]))([\p{L}\p{N}_-]+)/gmu;
 
 /**
  * Normalizes a tag by removing # prefix, trimming, and lowercasing

--- a/src/validation/schemas.test.ts
+++ b/src/validation/schemas.test.ts
@@ -531,6 +531,38 @@ describe('ValidationSchemas', () => {
           }),
         ).not.toThrow();
       });
+
+      it('allows CJK tags (Chinese / Japanese / Korean)', () => {
+        expect(() =>
+          CreateReminderSchema.parse({
+            title: 'CJK tagged reminder',
+            tags: ['雷蒙三十', '日本語', '한국어', '#中文_mix'],
+          }),
+        ).not.toThrow();
+      });
+
+      it('allows CJK tags in filterTags for read action', () => {
+        expect(() =>
+          ReadRemindersSchema.parse({
+            filterTags: ['雷蒙三十'],
+          }),
+        ).not.toThrow();
+      });
+
+      it('rejects tags with whitespace or punctuation', () => {
+        expect(() =>
+          CreateReminderSchema.parse({
+            title: 'Bad tag',
+            tags: ['has space'],
+          }),
+        ).toThrow();
+        expect(() =>
+          CreateReminderSchema.parse({
+            title: 'Bad tag',
+            tags: ['bad,comma'],
+          }),
+        ).toThrow();
+      });
     });
 
     describe('Action schemas validation patterns', () => {

--- a/src/validation/schemas.ts
+++ b/src/validation/schemas.ts
@@ -398,13 +398,15 @@ const AvailabilitySchema = z
 const SpanSchema = z.enum(['this-event', 'future-events']).optional();
 
 /**
- * Tag schema for reminder tags
+ * Tag schema for reminder tags.
+ * Allows Unicode letters and numbers so non-Latin scripts (CJK, Cyrillic,
+ * Arabic, etc.) work as tag names — Apple Reminders natively supports them.
  */
 const TagSchema = z
   .string()
   .min(1)
   .max(50)
-  .regex(/^#?[a-zA-Z0-9_-]+$/, {
+  .regex(/^#?[\p{L}\p{N}_-]+$/u, {
     message: 'Tags can only contain letters, numbers, underscores, and hyphens',
   });
 


### PR DESCRIPTION
## Summary

Apple Reminders natively allows tags in any script (Chinese, Japanese, Korean, Cyrillic, Arabic, etc.) — users type `#雷蒙三十` or `#日本語` directly into a reminder's notes and the Reminders app treats them as tags. Two paths in this MCP server were blocking those tags from working end-to-end:

1. **`BARE_TAG_REGEX` in `src/utils/tagUtils.ts`** only matched `[a-zA-Z0-9_-]`, so a reminder containing native `#漢字` tags returned an empty tags array from `extractTags()`.
2. **`TagSchema` in `src/validation/schemas.ts`** rejected the same characters server-side, making `tags` / `addTags` / `removeTags` / `filterTags` parameters unusable for any non-Latin tag value. Calling `reminders_tasks` with `filterTags: ["雷蒙三十"]` failed with `Tags can only contain letters, numbers, underscores, and hyphens`.

## Changes

- Body of both regexes now uses Unicode property classes `\p{L}\p{N}` with the `/u` flag. ASCII letters / digits / `_` / `-` continue to work unchanged.
- Replaced `\b` in the numeric-only lookahead with an explicit Unicode-aware lookahead `(?![\p{L}\p{N}_-])`. The old `\b` fired between ASCII digits and CJK letters (CJK chars count as `\W` in JS regex), causing tags like `#2024年` to be misclassified as purely-numeric and rejected.
- Tests cover Chinese / Japanese / Korean bare tags, mixed CJK + ASCII (`#中文_english`), digit-prefixed CJK (`#2024年`), `stripTags` behavior, and schema validation for both `tags` and `filterTags`.

## Test plan

- [x] All existing tests still pass (582 passed vs 574 on `main`; the 16 failing tests in `e2e.test.ts` / `publishedPackage.test.ts` are pre-existing environment issues unrelated to this change — they fail identically on clean `main`)
- [x] New CJK tests pass:
  - `extractTags('#雷蒙三十 #日本語 #한국어 notes')` → `['雷蒙三十', '日本語', '한국어']`
  - `extractTags('#中文_english #2024年 notes')` → `['中文_english', '2024年']`
  - `stripTags('#雷蒙三十 #日本語 Some notes')` → `'Some notes'`
  - `CreateReminderSchema.parse({ tags: ['雷蒙三十', '日本語', '한국어', '#中文_mix'] })` → no throw
  - `ReadRemindersSchema.parse({ filterTags: ['雷蒙三十'] })` → no throw
- [x] Existing edge cases still hold:
  - `#42` (pure numeric) still rejected
  - `#1st`, `#2024q1` (digit-prefixed Latin) still accepted
  - `foo#bar` (mid-word `#`) still rejected
  - Punctuation still terminates tags correctly

## Notes

- Refs #74 — that PR fixed tag extraction for ASCII tags; this extends the same parsing/validation to non-Latin scripts so the fix is consistent across Apple Reminders' actual capabilities.
- No public API change; `Tags can only contain letters, numbers, underscores, and hyphens` error message is unchanged (the word "letters" now correctly covers Unicode letters).
- Scope deliberately narrow: only the regex char class and the numeric-only lookahead. Pre-existing behavior around whitespace-as-separator (e.g. `#a,#b` requires whitespace between bare tags) is intentionally not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)