### PR TITLE
fix(validation): accept any valid URI scheme in URL field

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"6652d7a7-06c0-428c-ae46-82a6fe9f8fc6","pid":44968,"procStart":"Wed May 27 08:45:50 2026","acquiredAt":1779872398449}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"6652d7a7-06c0-428c-ae46-82a6fe9f8fc6","pid":44968,"procStart":"Wed May 27 08:45:50 2026","acquiredAt":1779872398449}

--- a/.gitignore
+++ b/.gitignore
@@ -180,3 +180,4 @@ dist
 
 # Swift compiled binaries
 *.swiftmodule
+.claude/

--- a/src/validation/schemas.test.ts
+++ b/src/validation/schemas.test.ts
@@ -257,6 +257,15 @@ describe('ValidationSchemas', () => {
           SafeUrlSchema.parse('https://example.com/\nfoo'),
         ).toThrow();
         expect(() =>
+          SafeUrlSchema.parse('https://example.com/\tfoo'),
+        ).toThrow();
+        expect(() =>
+          SafeUrlSchema.parse('https://example.com/\rfoo'),
+        ).toThrow();
+        expect(() =>
+          SafeUrlSchema.parse('https://example.com/\x00foo'),
+        ).toThrow();
+        expect(() =>
           SafeUrlSchema.parse('obsidian://open?file=my note'),
         ).toThrow();
       });
@@ -401,6 +410,43 @@ describe('ValidationSchemas', () => {
             expect(() =>
               SafeUrlSchema.parse('http://[fd00::1]/admin'),
             ).toThrow();
+          });
+        });
+
+        describe('IPv4-mapped IPv6 protection', () => {
+          // WHATWG URL normalises [::ffff:127.0.0.1] to [::ffff:7f00:1], so the
+          // dotted-quad form never reaches the blocklist. Decode the trailing
+          // two hextets and run them through the IPv4 blocklist.
+          it('should block ::ffff:127.0.0.1 loopback (dotted-quad input)', () => {
+            expect(() =>
+              SafeUrlSchema.parse('http://[::ffff:127.0.0.1]/admin'),
+            ).toThrow();
+          });
+
+          it('should block ::ffff:7f00:1 loopback (canonical hex form)', () => {
+            expect(() =>
+              SafeUrlSchema.parse('http://[::ffff:7f00:1]/admin'),
+            ).toThrow();
+          });
+
+          it('should block ::ffff:a9fe:a9fe (AWS metadata 169.254.169.254)', () => {
+            expect(() =>
+              SafeUrlSchema.parse(
+                'http://[::ffff:a9fe:a9fe]/latest/meta-data/',
+              ),
+            ).toThrow();
+          });
+
+          it('should block ::ffff:c0a8:1 (192.168.0.1 private)', () => {
+            expect(() =>
+              SafeUrlSchema.parse('http://[::ffff:c0a8:1]/admin'),
+            ).toThrow();
+          });
+
+          it('should not block ::ffff:0808:0808 (8.8.8.8 public)', () => {
+            expect(() =>
+              SafeUrlSchema.parse('http://[::ffff:0808:0808]/api'),
+            ).not.toThrow();
           });
         });
 

--- a/src/validation/schemas.test.ts
+++ b/src/validation/schemas.test.ts
@@ -227,7 +227,38 @@ describe('ValidationSchemas', () => {
 
       it('should reject invalid URL formats', () => {
         expect(() => SafeUrlSchema.parse('not-a-url')).toThrow();
-        expect(() => SafeUrlSchema.parse('ftp://example.com')).toThrow();
+        expect(() => SafeUrlSchema.parse('')).toThrow();
+      });
+
+      it('should accept custom app-deep-link URI schemes (issue #101)', () => {
+        // EventKit's EKReminder.url accepts any NSURL, so the MCP layer must
+        // not be stricter than the underlying API.
+        expect(() =>
+          SafeUrlSchema.parse('obsidian://open?vault=MyVault&file=my-note'),
+        ).not.toThrow();
+        expect(() =>
+          SafeUrlSchema.parse('shortcuts://run-shortcut?name=MyShortcut'),
+        ).not.toThrow();
+        expect(() =>
+          SafeUrlSchema.parse('bear://x-callback-url/open-note?id=123'),
+        ).not.toThrow();
+        expect(() => SafeUrlSchema.parse('tel:+1234567890')).not.toThrow();
+        expect(() =>
+          SafeUrlSchema.parse('mailto:user@example.com'),
+        ).not.toThrow();
+        expect(() =>
+          SafeUrlSchema.parse('omnifocus:///add?name=Task'),
+        ).not.toThrow();
+      });
+
+      it('should reject URLs containing whitespace or control chars', () => {
+        expect(() => SafeUrlSchema.parse('https://example.com/ a')).toThrow();
+        expect(() =>
+          SafeUrlSchema.parse('https://example.com/\nfoo'),
+        ).toThrow();
+        expect(() =>
+          SafeUrlSchema.parse('obsidian://open?file=my note'),
+        ).toThrow();
       });
 
       describe('SSRF Protection', () => {
@@ -502,23 +533,35 @@ describe('ValidationSchemas', () => {
         });
 
         describe('Protocol restrictions', () => {
-          it('should reject non-HTTP protocols', () => {
+          it('should reject dangerous protocols regardless of host', () => {
             expect(() => SafeUrlSchema.parse('file:///etc/passwd')).toThrow();
-            expect(() => SafeUrlSchema.parse('ftp://example.com')).toThrow();
+            expect(() => SafeUrlSchema.parse('javascript:alert(1)')).toThrow();
+            expect(() => SafeUrlSchema.parse('vbscript:msgbox("x")')).toThrow();
+            expect(() =>
+              SafeUrlSchema.parse('data:text/html,<script>alert(1)</script>'),
+            ).toThrow();
             expect(() =>
               SafeUrlSchema.parse('jar:http://evil.com!/'),
             ).toThrow();
             expect(() =>
               SafeUrlSchema.parse('dict://127.0.0.1:11211/'),
             ).toThrow();
+            expect(() =>
+              SafeUrlSchema.parse('gopher://example.com/'),
+            ).toThrow();
           });
 
-          it('should only allow http and https', () => {
+          it('should allow http, https, and arbitrary app schemes', () => {
             expect(() =>
               SafeUrlSchema.parse('http://example.com'),
             ).not.toThrow();
             expect(() =>
               SafeUrlSchema.parse('https://example.com'),
+            ).not.toThrow();
+            // ftp is now accepted — the model can store any URI and the
+            // user (not this server) is the one that follows the link.
+            expect(() =>
+              SafeUrlSchema.parse('ftp://example.com'),
             ).not.toThrow();
           });
         });

--- a/src/validation/schemas.ts
+++ b/src/validation/schemas.ts
@@ -147,6 +147,34 @@ function isBlockedHostname(hostname: string): boolean {
   // 2001:db8::/32 (documentation)
   if (/^2001:db8:/i.test(ipv6Hostname)) return true;
 
+  // ::ffff:0:0/96 (IPv4-mapped IPv6). WHATWG URL normalises `[::ffff:127.0.0.1]`
+  // to `[::ffff:7f00:1]`, so the dotted-quad form is gone by the time we look
+  // at the hostname. Decode the trailing two hextets and run them through the
+  // IPv4 blocklist so a mapped form of any blocked v4 address (loopback,
+  // private, link-local, cloud metadata) is rejected too.
+  //
+  // Accepts both shorthand (`::ffff:7f00:1`) and the fully expanded form
+  // (`0:0:0:0:0:ffff:7f00:1`).
+  const ipv4MappedMatch = ipv6Hostname.match(
+    /^(?:::|(?:0:){5})ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i,
+  );
+  if (ipv4MappedMatch) {
+    const high = parseInt(ipv4MappedMatch[1]!, 16);
+    const low = parseInt(ipv4MappedMatch[2]!, 16);
+    if (
+      !Number.isNaN(high) &&
+      !Number.isNaN(low) &&
+      isBlockedIPv4(
+        (high >>> 8) & 255,
+        high & 255,
+        (low >>> 8) & 255,
+        low & 255,
+      )
+    ) {
+      return true;
+    }
+  }
+
   return false;
 }
 

--- a/src/validation/schemas.ts
+++ b/src/validation/schemas.ts
@@ -13,18 +13,50 @@ const SAFE_TEXT_PATTERN =
 // later collapse to an unbounded EventKit query in the Swift CLI.
 const DATE_PATTERN =
   /^(\d{4})-(\d{2})-(\d{2})(?:[ T](\d{2}):(\d{2})(?::(\d{2}))?(?:\.\d{1,9})?(?:Z|[+-]\d{2}:?\d{2})?)?$/;
-// URL validation that blocks internal/private network addresses and localhost
-// Prevents SSRF attacks while allowing legitimate external URLs
-// Blocks: IPv4 private/reserved (127.x, 192.168.x, 10.x, 172.16-31.x, 169.254.x, 0.0.0.0, 224-239.x multicast)
-// Blocks: IPv6 loopback (::1), unspecified (::), link-local (fe80::), private (fc/fd), multicast (ff)
-// Blocks: Cloud metadata (169.254.169.254, 100.100.100.200, metadata.google.internal)
-// Blocks: Internal hostnames (localhost, localhost.localdomain, local, internal)
+// URL validation: accept any valid URI (any scheme) so reminders can link to
+// custom-scheme deep links like obsidian://, shortcuts://, tel:, mailto: —
+// EventKit's EKReminder.url accepts any NSURL, so the MCP layer should not be
+// stricter than the underlying API (see issue #101).
+//
+// For http(s) URLs we still apply SSRF protection (private/internal addresses,
+// localhost, cloud metadata) because those map to real network hostnames the
+// model might be tricked into emitting. Custom schemes are app-handled by
+// macOS and don't reach the network through us, so scheme-validation alone is
+// sufficient there.
+//
+// We still reject a small set of schemes that are dangerous regardless of
+// hostname: file (local filesystem), javascript / vbscript (script execution
+// in any client that renders the link), jar / dict / gopher (historical SSRF
+// vectors via URL handlers), and data (can carry executable content).
+//
+// SSRF blocklist for http(s) hostnames:
+// - IPv4 private/reserved (127.x, 192.168.x, 10.x, 172.16-31.x, 169.254.x, 0.0.0.0, 224-239.x multicast)
+// - IPv6 loopback (::1), unspecified (::), link-local (fe80::), private (fc/fd), multicast (ff)
+// - Cloud metadata (169.254.169.254, 100.100.100.200, metadata.google.internal)
+// - Internal hostnames (localhost, localhost.localdomain, local, internal)
 // Note: For production use, consider using a dedicated SSRF protection library
 
-// Base URL pattern for HTTP/HTTPS with basic structure validation
-// SSRF checks are done via refinement function for accuracy
-const URL_PATTERN =
-  /^https?:\/\/(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*|\[[0-9a-fA-F:]+\])(?::\d+)?(?:\/[^\s<>"{}|\\^`[\]]*)?$/i;
+// Schemes that are dangerous regardless of host — block unconditionally.
+// Compared case-insensitively against URL.protocol which includes the colon.
+const BLOCKED_URL_SCHEMES = new Set([
+  'file:',
+  'javascript:',
+  'vbscript:',
+  'data:',
+  'jar:',
+  'dict:',
+  'gopher:',
+]);
+
+// Schemes that resolve to a network hostname and therefore need SSRF checks.
+// Other schemes (mailto:, tel:, obsidian://, shortcuts://, ...) are app-routed
+// by macOS and never reach the network through this process.
+const HOST_BASED_URL_SCHEMES = new Set(['http:', 'https:']);
+
+// Reject control characters and whitespace anywhere in the URL — the URL
+// parser is lenient about some of these and we want a strict input.
+// biome-ignore lint/suspicious/noControlCharactersInRegex: intentional — must catch raw control chars and DEL injected into URLs
+const URL_FORBIDDEN_CHARS = /[\s\x00-\x1f\x7f]/;
 
 /**
  * Checks if a hostname is blocked for SSRF protection
@@ -302,21 +334,53 @@ const createRequiredDateSchema = (fieldName: string) =>
       `${fieldName} must be a real, parseable date/time`,
     );
 
+/**
+ * Validates a URL string against the project's URI policy.
+ *
+ * Accepts any valid URI so reminders can hold app-deep-link schemes such as
+ * `obsidian://`, `shortcuts://`, `tel:`, and `mailto:` — EventKit itself
+ * accepts any NSURL (issue #101). Schemes in {@link BLOCKED_URL_SCHEMES}
+ * (file, javascript, data, …) are rejected unconditionally, and for the
+ * host-based schemes in {@link HOST_BASED_URL_SCHEMES} (http/https) the
+ * SSRF hostname blocklist still applies.
+ *
+ * @returns `true` if accepted, otherwise an error message describing why.
+ */
+function validateUrl(url: string): true | string {
+  if (URL_FORBIDDEN_CHARS.test(url)) {
+    return 'URL cannot contain whitespace or control characters';
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return 'URL must be a valid URI (RFC 3986)';
+  }
+  const scheme = parsed.protocol.toLowerCase();
+  if (BLOCKED_URL_SCHEMES.has(scheme)) {
+    return `URL scheme '${scheme}' is not allowed`;
+  }
+  if (
+    HOST_BASED_URL_SCHEMES.has(scheme) &&
+    isBlockedHostname(parsed.hostname)
+  ) {
+    return 'URL must not point to internal, private, or blocked addresses';
+  }
+  return true;
+}
+
 export const SafeUrlSchema = z
   .string()
-  .regex(URL_PATTERN, 'URL must be a valid HTTP or HTTPS URL')
   .max(
     VALIDATION.MAX_URL_LENGTH,
     `URL cannot exceed ${VALIDATION.MAX_URL_LENGTH} characters`,
   )
-  .refine((url) => {
-    try {
-      const parsed = new URL(url);
-      return !isBlockedHostname(parsed.hostname);
-    } catch {
-      return false;
+  .superRefine((url, ctx) => {
+    const result = validateUrl(url);
+    if (result !== true) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: result });
     }
-  }, 'URL must not point to internal, private, or blocked addresses')
+  })
   .optional();
 
 // Reusable schemas for common fields


### PR DESCRIPTION
Closes #101.

## Problem

`SafeUrlSchema` rejected any URL whose scheme was not `http` or `https`, so reminders could not hold app-deep-link URIs that EventKit itself accepts:

- `obsidian://open?vault=…&file=…`
- `shortcuts://run-shortcut?name=…`
- `bear://x-callback-url/…`
- `omnifocus:///add?name=…`
- `tel:+1234567890`
- `mailto:user@example.com`

`EKReminder.url` accepts any `NSURL`, so the MCP layer was stricter than the underlying API.

## Fix

`SafeUrlSchema` now:

1. Rejects control characters / whitespace anywhere in the URL.
2. Parses with `new URL()` — any URI that parses is structurally valid.
3. Rejects a small unconditional blocklist of dangerous schemes regardless of host: `file`, `javascript`, `vbscript`, `data`, `jar`, `dict`, `gopher`.
4. Keeps the existing SSRF hostname blocklist, but only applies it to `http:` and `https:` — those are the only schemes that resolve to a network host through this process.
5. Custom schemes (`obsidian:`, `shortcuts:`, `tel:`, `mailto:`, …) pass through to EventKit, which forwards them to the registered handler on tap.

## Tests

- New positive cases for `obsidian://`, `shortcuts://`, `bear://`, `omnifocus:///`, `tel:`, `mailto:`.
- New negative cases for the blocked-scheme list (`javascript:`, `vbscript:`, `data:`, `gopher:`) and for whitespace / control chars in the URL.
- The previous "ftp is rejected" assertion is replaced with the new policy.
- All 631 existing tests still pass.

```
pnpm check   # biome + tsc, clean
pnpm test    # 33 suites / 631 tests, all green
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)