### PR TITLE
docs(permissions): document desktop MCP client TCC workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,26 +82,33 @@ You can also re-run `./check-permissions.sh` (it now validates both Reminders an
 
 ### Desktop MCP clients (Claude Desktop, Codex Desktop, …)
 
-macOS attributes Reminders and Calendar access to the **responsible** process — the desktop app that launched the MCP server, not the `EventKitCLI` subprocess. The TCC daemon refuses to display a permission prompt if the responsible app has not declared the corresponding usage descriptions and entitlements (see [issue #93](https://github.com/FradSer/mcp-server-apple-events/issues/93)). This is a macOS-level constraint that an MCP server alone cannot solve.
-
-If your desktop client does not declare Reminders/Calendar usage strings (Codex Desktop, for example, only declares `NSAppleEventsUsageDescription`), the Swift CLI will report:
+macOS attributes Reminders and Calendar access to the **responsible** process — the desktop app that launched the MCP server, not the `EventKitCLI` subprocess. For the EventKit prompt to appear, the responsible app's bundle must ship the `NSRemindersUsageDescription` / `NSCalendarsUsageDescription` keys (and on Sonoma+ the matching write-only or full-access variants). If those keys are missing, TCC refuses the request before EventKit is even reached, and the Swift CLI returns:
 
 ```text
 Reminder permission denied. Unknown error
 ```
 
-…even though running the same binary from Terminal works.
+— even though running the same binary from Terminal works. See [issue #93](https://github.com/FradSer/mcp-server-apple-events/issues/93) for the full TCC log; Codex Desktop today ships only `NSAppleEventsUsageDescription`, which is why it hits this wall.
 
-**Recommended workaround.** Trigger the native prompt once through AppleScript, which routes the request through `com.apple.systemevents` rather than the desktop app's bundle ID:
+This is a macOS-level constraint that an MCP server alone cannot resolve — the desktop client itself needs to declare those usage strings in its `Info.plist`. The workarounds below are about making the server *usable* while you wait for the upstream fix:
+
+**Reliable workaround — run the server from a terminal-based MCP client.** Codex CLI, Claude Code, and similar terminal-launched clients inherit Terminal's (or iTerm2's) own `kTCCServiceReminders` / `kTCCServiceCalendar` grant, so EventKit calls succeed without changes to this server:
+
+```bash
+# from inside Terminal / iTerm2, where the responsible app holds the EventKit grants
+codex
+# or
+claude
+```
+
+**Partial workaround — AppleScript routing (only if the desktop app already declares `NSAppleEventsUsageDescription`).** Running:
 
 ```bash
 osascript -e 'tell application "Reminders" to get name of lists'
 osascript -e 'tell application "Calendar" to get name of calendars'
 ```
 
-Approve the dialog when it appears, then retry the MCP call. Once the responsible app holds the permission, subsequent calls succeed without further prompts.
-
-**If that still fails**, run this server from a terminal-based MCP client (Codex CLI, Claude Code, etc.) instead — Terminal can hold the permissions on the desktop app's behalf.
+triggers an **Automation** prompt (`kTCCServiceAppleEvents`) so the responsible app can control `com.apple.reminders` and `com.apple.iCal`. This does *not* create a `kTCCServiceReminders` / `kTCCServiceCalendar` grant on its own, so a Swift CLI that calls EventKit directly will still be refused if the host bundle is missing the usage strings. It only helps if your client can fall back to AppleScript end-to-end (this server does not today).
 
 **Verification command**
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,29 @@ If you see `Failed to read calendar events`, verify Calendar is set to **Full Ca
 
 You can also re-run `./check-permissions.sh` (it now validates both Reminders and Calendars access).
 
+### Desktop MCP clients (Claude Desktop, Codex Desktop, …)
+
+macOS attributes Reminders and Calendar access to the **responsible** process — the desktop app that launched the MCP server, not the `EventKitCLI` subprocess. The TCC daemon refuses to display a permission prompt if the responsible app has not declared the corresponding usage descriptions and entitlements (see [issue #93](https://github.com/FradSer/mcp-server-apple-events/issues/93)). This is a macOS-level constraint that an MCP server alone cannot solve.
+
+If your desktop client does not declare Reminders/Calendar usage strings (Codex Desktop, for example, only declares `NSAppleEventsUsageDescription`), the Swift CLI will report:
+
+```text
+Reminder permission denied. Unknown error
+```
+
+…even though running the same binary from Terminal works.
+
+**Recommended workaround.** Trigger the native prompt once through AppleScript, which routes the request through `com.apple.systemevents` rather than the desktop app's bundle ID:
+
+```bash
+osascript -e 'tell application "Reminders" to get name of lists'
+osascript -e 'tell application "Calendar" to get name of calendars'
+```
+
+Approve the dialog when it appears, then retry the MCP call. Once the responsible app holds the permission, subsequent calls succeed without further prompts.
+
+**If that still fails**, run this server from a terminal-based MCP client (Codex CLI, Claude Code, etc.) instead — Terminal can hold the permissions on the desktop app's behalf.
+
 **Verification command**
 
 ```bash

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -78,26 +78,33 @@ Apple 已将提醒事项和日历权限拆分为「仅写入」与「完全访�
 
 ### 桌面端 MCP 客户端（Claude Desktop、Codex Desktop 等）
 
-macOS 把提醒事项与日历的访问权限归属到 **responsible（负责）** 进程——也就是启动 MCP 服务的桌面应用本身，而不是 `EventKitCLI` 子进程。如果负责的应用没有在 `Info.plist` 中声明对应的 usage description 与 entitlements，TCC 守护进程会直接拒绝请求、不弹出授权窗口（参见 [issue #93](https://github.com/FradSer/mcp-server-apple-events/issues/93)）。这是 macOS 层面的限制，单凭 MCP 服务无法绕过。
-
-如果你的桌面客户端未声明 Reminders/Calendar 的 usage 字段（例如 Codex Desktop 只声明了 `NSAppleEventsUsageDescription`），Swift CLI 会返回：
+macOS 把提醒事项与日历的访问权限归属到 **responsible（负责）** 进程——也就是启动 MCP 服务的桌面应用本身，而不是 `EventKitCLI` 子进程。要让 EventKit 弹出授权对话框，负责应用的 bundle 必须在自己的 `Info.plist` 中声明 `NSRemindersUsageDescription` / `NSCalendarsUsageDescription`（macOS Sonoma 之后还需要写入权限或完全访问权限的对应键）。如果这些键缺失，TCC 会在请求到达 EventKit 之前就拒绝它，Swift CLI 会返回：
 
 ```text
 Reminder permission denied. Unknown error
 ```
 
-——即使同一个二进制在 Terminal 中可以正常使用。
+——即使同一个二进制在 Terminal 中可以正常工作。完整的 TCC 日志见 [issue #93](https://github.com/FradSer/mcp-server-apple-events/issues/93)。目前 Codex Desktop 只声明了 `NSAppleEventsUsageDescription`，这就是它会撞到这堵墙的原因。
 
-**推荐的临时解决方案。** 先通过 AppleScript 触发一次原生授权对话框，把请求路由到 `com.apple.systemevents` 而不是桌面应用自身：
+这是 macOS 层面的限制，单凭 MCP 服务无法绕过——只有桌面客户端自己在 `Info.plist` 里加上对应的 usage description 才能根治。在等待上游修复期间，下面的两个方案能让本服务保持可用：
+
+**可靠方案——使用基于终端的 MCP 客户端启动本服务。** Codex CLI、Claude Code 等在终端中启动的客户端会继承 Terminal / iTerm2 已经持有的 `kTCCServiceReminders` / `kTCCServiceCalendar` 授权，本服务无需修改即可正常调用 EventKit：
+
+```bash
+# 在 Terminal / iTerm2 里运行，由它充当 responsible app
+codex
+# 或
+claude
+```
+
+**部分方案——AppleScript 路由（仅当桌面应用已声明 `NSAppleEventsUsageDescription` 时有效）。** 运行：
 
 ```bash
 osascript -e 'tell application "Reminders" to get name of lists'
 osascript -e 'tell application "Calendar" to get name of calendars'
 ```
 
-在弹窗中点击同意，然后重新触发 MCP 调用。一旦负责的应用获得了权限，后续调用就能直接成功，不会再次弹窗。
-
-**如果仍然失败**，请改用基于终端的 MCP 客户端（Codex CLI、Claude Code 等）来启动本服务——Terminal 已经持有这些权限，可以替代桌面应用承担授权请求。
+会触发一次 **Automation** 授权请求（`kTCCServiceAppleEvents`），允许负责应用控制 `com.apple.reminders` 与 `com.apple.iCal`。但这并不会顺带创建 `kTCCServiceReminders` / `kTCCServiceCalendar` 授权记录，所以一个直接调用 EventKit 的 Swift CLI 在 host bundle 缺少 usage description 时仍然会被拒。只有当你的客户端能够端到端走 AppleScript 时这套方案才生效（本服务目前并不会这么做）。
 
 **验证命令**
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -76,6 +76,29 @@ Apple 已将提醒事项和日历权限拆分为「仅写入」与「完全访�
 
 你也可以重新运行 `./check-permissions.sh`（脚本现在会同时检查 Reminders 与 Calendars 权限）。
 
+### 桌面端 MCP 客户端（Claude Desktop、Codex Desktop 等）
+
+macOS 把提醒事项与日历的访问权限归属到 **responsible（负责）** 进程——也就是启动 MCP 服务的桌面应用本身，而不是 `EventKitCLI` 子进程。如果负责的应用没有在 `Info.plist` 中声明对应的 usage description 与 entitlements，TCC 守护进程会直接拒绝请求、不弹出授权窗口（参见 [issue #93](https://github.com/FradSer/mcp-server-apple-events/issues/93)）。这是 macOS 层面的限制，单凭 MCP 服务无法绕过。
+
+如果你的桌面客户端未声明 Reminders/Calendar 的 usage 字段（例如 Codex Desktop 只声明了 `NSAppleEventsUsageDescription`），Swift CLI 会返回：
+
+```text
+Reminder permission denied. Unknown error
+```
+
+——即使同一个二进制在 Terminal 中可以正常使用。
+
+**推荐的临时解决方案。** 先通过 AppleScript 触发一次原生授权对话框，把请求路由到 `com.apple.systemevents` 而不是桌面应用自身：
+
+```bash
+osascript -e 'tell application "Reminders" to get name of lists'
+osascript -e 'tell application "Calendar" to get name of calendars'
+```
+
+在弹窗中点击同意，然后重新触发 MCP 调用。一旦负责的应用获得了权限，后续调用就能直接成功，不会再次弹窗。
+
+**如果仍然失败**，请改用基于终端的 MCP 客户端（Codex CLI、Claude Code 等）来启动本服务——Terminal 已经持有这些权限，可以替代桌面应用承担授权请求。
+
 **验证命令**
 
 ```bash

--- a/check-permissions.sh
+++ b/check-permissions.sh
@@ -42,16 +42,6 @@ else
     exit 1
 fi
 
-# Some desktop MCP clients (Codex Desktop, Claude Desktop) cannot trigger the
-# native Reminders/Calendar prompt directly because TCC attributes the request
-# to the host app, which lacks the usage-description keys. Pre-prompting via
-# AppleScript routes the request through the Reminders/Calendar apps, which is
-# enough for macOS to associate the permission with the responsible app.
-# See: https://github.com/FradSer/mcp-server-apple-events/issues/93
-echo "Pre-prompting Reminders/Calendar via AppleScript (for desktop MCP clients)..."
-osascript -e 'tell application "Reminders" to get name of lists' >/dev/null 2>&1 || true
-osascript -e 'tell application "Calendar" to get name of calendars' >/dev/null 2>&1 || true
-
 echo ""
 echo "All permission checks passed."
 echo "Apple Events MCP Server is ready to run."

--- a/check-permissions.sh
+++ b/check-permissions.sh
@@ -42,6 +42,16 @@ else
     exit 1
 fi
 
+# Some desktop MCP clients (Codex Desktop, Claude Desktop) cannot trigger the
+# native Reminders/Calendar prompt directly because TCC attributes the request
+# to the host app, which lacks the usage-description keys. Pre-prompting via
+# AppleScript routes the request through the Reminders/Calendar apps, which is
+# enough for macOS to associate the permission with the responsible app.
+# See: https://github.com/FradSer/mcp-server-apple-events/issues/93
+echo "Pre-prompting Reminders/Calendar via AppleScript (for desktop MCP clients)..."
+osascript -e 'tell application "Reminders" to get name of lists' >/dev/null 2>&1 || true
+osascript -e 'tell application "Calendar" to get name of calendars' >/dev/null 2>&1 || true
+
 echo ""
 echo "All permission checks passed."
 echo "Apple Events MCP Server is ready to run."


### PR DESCRIPTION
Refs #93.

## Context

macOS attributes Reminders and Calendar access to the **responsible** process — the desktop MCP client that launched this server (e.g. Codex Desktop, Claude Desktop), not the `EventKitCLI` subprocess. If the client only declares `NSAppleEventsUsageDescription` (as Codex Desktop does), the TCC daemon refuses the EventKit request and the MCP server has no way to surface the system prompt on its own. The TCC logs in the issue confirm this:

> service: kTCCServiceReminders … without NSRemindersUsageDescription key
> responsible=com.openai.codex

That's a macOS-level constraint that can't be fully fixed inside an MCP package, but the symptom is confusing because the binary works fine when launched from Terminal. This PR documents the situation and the known workaround.

## Changes

- **README.md / README.zh-CN.md**: new *Desktop MCP clients* subsection under macOS Permission Requirements. Explains the TCC attribution issue, gives the `osascript` pre-prompt workaround suggested by @chen4study-hub, and falls back to "use a terminal MCP client" if the workaround does not stick.
- **check-permissions.sh**: after the existing checks, run a best-effort AppleScript pre-prompt for both Reminders and Calendar so the responsible app sees the request at least once.

## Why this is "docs" not "fix"

The Swift CLI's `requestFullAccessTo…` call cannot trigger a prompt when the responsible app lacks the usage-description keys — TCC refuses before EventKit is even reached. The only code-level mitigation would be a full AppleScript fallback path for every operation, which is out of scope for this PR and is also why the upstream desktop apps need to declare the keys themselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)