### PR TITLE
fix: post-merge review cleanups (NAT64 SSRF + stale docs)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,4 +180,9 @@ dist
 
 # Swift compiled binaries
 *.swiftmodule
-.claude/
+
+# Local Claude Code session artifacts only — leave shared project config
+# (e.g. .claude/git.local.md, future .claude/settings.json) tracked.
+.claude/scheduled_tasks.lock
+.claude/local/
+.claude/state/

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Apple now separates Reminders and Calendar permissions into _write-only_ and _fu
 
 When the CLI detects a `notDetermined` authorization status it calls `requestFullAccessToReminders` / `requestFullAccessToEvents`, which in turn triggers macOS to show the correct prompt. If the OS ever loses track of permissions, rerun `./check-permissions.sh` to re-open the dialogs.
 
-If a Claude tool call still encounters a permission failure, the Node.js layer automatically runs a minimal AppleScript (`osascript -e 'tell application "Reminders" …'`) to surface the dialog and then retries the Swift CLI once.
+If a Claude tool call still encounters a permission failure, see *Desktop MCP clients* below for the responsible-process attribution problem and the recommended workarounds.
 
 ### Troubleshooting Calendar Read Errors
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -62,7 +62,7 @@ Apple 已将提醒事项和日历权限拆分为「仅写入」与「完全访�
 
 当授权状态为 `notDetermined` 时，CLI 会调用 `requestFullAccessToReminders` / `requestFullAccessToEvents`，macOS 会弹出对应的授权对话框。如果系统遗失权限记录，可运行 `./check-permissions.sh` 重新触发请求。
 
-若 Claude 的工具调用依旧遇到权限错误，Node.js 层会自动运行一段最小化的 AppleScript（`osascript -e 'tell application "Reminders" …'`）来唤起系统弹窗，然后再次重试 Swift CLI。
+若 Claude 的工具调用依旧遇到权限错误，请参阅下方的 *桌面端 MCP 客户端* 一节——那里描述了 responsible 进程归属问题以及推荐的解决方案。
 
 ### 日历读取报错排查
 

--- a/src/validation/schemas.test.ts
+++ b/src/validation/schemas.test.ts
@@ -450,6 +450,39 @@ describe('ValidationSchemas', () => {
           });
         });
 
+        describe('NAT64 prefix protection (RFC 6052)', () => {
+          // 64:ff9b::/96 is the well-known NAT64 prefix. On NAT64-active
+          // networks (default on iOS cellular and many enterprise networks)
+          // these addresses are routed to the embedded IPv4 by the gateway,
+          // so they're an SSRF vector even though the host itself doesn't
+          // speak IPv4. Block them the same way ::ffff:* is blocked.
+          it('should block 64:ff9b::7f00:1 (loopback via NAT64)', () => {
+            expect(() =>
+              SafeUrlSchema.parse('http://[64:ff9b::7f00:1]/admin'),
+            ).toThrow();
+          });
+
+          it('should block 64:ff9b::a9fe:a9fe (AWS metadata via NAT64)', () => {
+            expect(() =>
+              SafeUrlSchema.parse(
+                'http://[64:ff9b::a9fe:a9fe]/latest/meta-data/',
+              ),
+            ).toThrow();
+          });
+
+          it('should block 64:ff9b::c0a8:1 (192.168.0.1 via NAT64)', () => {
+            expect(() =>
+              SafeUrlSchema.parse('http://[64:ff9b::c0a8:1]/admin'),
+            ).toThrow();
+          });
+
+          it('should not block 64:ff9b::0808:0808 (8.8.8.8 via NAT64)', () => {
+            expect(() =>
+              SafeUrlSchema.parse('http://[64:ff9b::0808:0808]/api'),
+            ).not.toThrow();
+          });
+        });
+
         describe('IPv6 documentation prefix', () => {
           it('should block 2001:db8::/32 range', () => {
             expect(() =>

--- a/src/validation/schemas.ts
+++ b/src/validation/schemas.ts
@@ -147,23 +147,21 @@ function isBlockedHostname(hostname: string): boolean {
   // 2001:db8::/32 (documentation)
   if (/^2001:db8:/i.test(ipv6Hostname)) return true;
 
-  // ::ffff:0:0/96 (IPv4-mapped IPv6). WHATWG URL normalises `[::ffff:127.0.0.1]`
-  // to `[::ffff:7f00:1]`, so the dotted-quad form is gone by the time we look
-  // at the hostname. Decode the trailing two hextets and run them through the
-  // IPv4 blocklist so a mapped form of any blocked v4 address (loopback,
-  // private, link-local, cloud metadata) is rejected too.
-  //
-  // Accepts both shorthand (`::ffff:7f00:1`) and the fully expanded form
-  // (`0:0:0:0:0:ffff:7f00:1`).
-  const ipv4MappedMatch = ipv6Hostname.match(
-    /^(?:::|(?:0:){5})ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i,
+  // ::ffff:0:0/96 (IPv4-mapped IPv6) and 64:ff9b::/96 (NAT64, RFC 6052).
+  // WHATWG URL normalises `[::ffff:127.0.0.1]` to `[::ffff:7f00:1]` and the
+  // fully expanded form back to the same shorthand, so by the time we look at
+  // the hostname only the shorthand reaches here. Decode the trailing two
+  // hextets and run them through the IPv4 blocklist so a mapped or NAT64
+  // form of any blocked v4 address (loopback, private, link-local, cloud
+  // metadata) is rejected too — on NAT64-active hosts `[64:ff9b::7f00:1]`
+  // is routed straight to 127.0.0.1 by the gateway.
+  const v4EmbeddedMatch = ipv6Hostname.match(
+    /^(?:::ffff:|64:ff9b::)([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i,
   );
-  if (ipv4MappedMatch) {
-    const high = parseInt(ipv4MappedMatch[1]!, 16);
-    const low = parseInt(ipv4MappedMatch[2]!, 16);
+  if (v4EmbeddedMatch) {
+    const high = parseInt(v4EmbeddedMatch[1]!, 16);
+    const low = parseInt(v4EmbeddedMatch[2]!, 16);
     if (
-      !Number.isNaN(high) &&
-      !Number.isNaN(low) &&
       isBlockedIPv4(
         (high >>> 8) & 255,
         high & 255,


### PR DESCRIPTION
Follow-up to #103 / #104. A 4-finder review pass after both PRs merged surfaced gaps in the SSRF blocklist, dead code, and stale README claims. This PR applies the survivors.

## Applied

1. **NAT64 prefix `64:ff9b::/96` (RFC 6052) was unblocked.** On hosts with NAT64 active (default on iOS cellular and many enterprise networks), `[64:ff9b::7f00:1]` is routed straight to 127.0.0.1 and `[64:ff9b::a9fe:a9fe]` reaches AWS metadata 169.254.169.254. The new IPv4-mapped block from #103 already decoded the trailing two hextets of `::ffff:HHHH:LLLL` against `isBlockedIPv4`; this PR broadens the same mechanism to `64:ff9b::HHHH:LLLL`. The regex changed from `^::ffff:HHHH:LLLL$` to `^(?:::ffff:|64:ff9b::)HHHH:LLLL$`. New tests cover NAT64 loopback, AWS metadata, 192.168.0.1, and a non-blocked public control (8.8.8.8 via NAT64).
2. **Removed dead `(?:0:){5}` branch from the IPv4-mapped regex.** WHATWG URL always normalises `[0:0:0:0:0:ffff:7f00:1]` to `[::ffff:7f00:1]` before \`isBlockedHostname\` sees it, so the fully-expanded form was unreachable.
3. **Removed dead \`Number.isNaN\` guards.** Both regex captures are constrained to \`[0-9a-f]{1,4}\` so \`parseInt(_, 16)\` cannot return NaN. The existing IPv4 block on line 121 already uses raw \`Number(_)\` without a NaN guard — consistency restored.
4. **Removed stale README claim about automatic AppleScript fallback.** Both \`README.md\` and \`README.zh-CN.md\` still asserted *"the Node.js layer automatically runs a minimal AppleScript … and retries the Swift CLI once."* No such fallback exists in \`src/utils/cliExecutor.ts\` — \`runCli\` throws \`CliPermissionError\` on permission failure, zero osascript invocation. The new *Desktop MCP clients* section added in #104 already ends with *"this server does not [do AppleScript end-to-end] today"*, which directly contradicted the older paragraph. Replaced both with a pointer to that new section.
5. **Narrowed \`.gitignore\` from bare \`.claude/\` to the specific local artifacts.** The previous rule would have silently hidden future shared project config like \`.claude/settings.json\`. Now ignores only \`scheduled_tasks.lock\`, \`.claude/local/\`, \`.claude/state/\`.

## Skipped (with reasons)

- **IPv4-compatible IPv6 (\`::a.b.c.d\`)** — RFC 4291-deprecated (2006); modern stacks do not route \`::H:L\` to the embedded IPv4. A blanket block on \`::HHHH:LLLL\` would catch ordinary low-value IPv6 like \`::1:1\` (false-positive risk too high).
- **ZWSP / bidi-override Unicode in \`URL_FORBIDDEN_CHARS\`** — Comment scope is "control characters and whitespace". Unicode formatting characters are a phishing concern but out of scope for this defence layer.
- **superRefine stacks issues with \`.max()\` on over-length URLs** — Verified that the prior \`.refine(...)\` chain had the same behaviour (zod's max issue is non-fatal). Not a regression from #103.
- **ftp/ws/wss + private hosts now pass; \`view-source:\` / \`blob:\` accepted** — Intentional per the #103 "accept any URI" policy. The server stores URLs; the user (not this server) follows the link.

## Verification

- \`pnpm test\` — 33 suites / **640 tests** green (4 new NAT64 cases).
- \`pnpm check\` — biome + tsc clean. Branch coverage 81.41% (threshold 78%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)