### PR TITLE
fix: make event its own TCC-responsible process so EventKit prompts work from any desktop MCP client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,6 +162,7 @@ dist
 
 # Compiled Swift binaries
 /bin/event
+/bin/event-disclaim
 
 # vendored event package build output
 /vendor/event/.build/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,4 +32,4 @@ macOS permissions for Reminders and Calendar are requested by the vendored [`eve
 - If notDetermined: requests permission automatically via `requestFullAccessToReminders` / `requestFullAccessToEvents`
 - If denied / restricted / write-only: emits `Error: Permission denied: …` on stderr with a non-zero exit code
 
-`src/utils/eventCli.ts` maps that stderr message into a domain-typed `CliPermissionError`. TypeScript handlers do not duplicate permission checks. Permission prompts are attributed to whichever host process spawns `bin/event` (e.g. Claude Desktop) — `event` carries no embedded Info.plist of its own.
+`src/utils/eventCli.ts` maps that stderr message into a domain-typed `CliPermissionError`. TypeScript handlers do not duplicate permission checks. `eventCli.ts` spawns `bin/event` through the `bin/event-disclaim` TCC shim (falling back to a direct, host-attributed spawn when the shim is absent), so permission prompts are attributed to `event` itself (it embeds an Info.plist with the EventKit usage strings) rather than to the host MCP client (issue #93).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **EventKit permission prompts now appear from any desktop MCP client**
+  (Codex Desktop, Claude Desktop, Cursor, …) — fixes
+  [#93](https://github.com/FradSer/mcp-server-apple-events/issues/93).
+  Previously macOS TCC attributed the Reminders/Calendar request to the
+  desktop app that launched the server; when that app lacked the EventKit
+  usage strings (Codex Desktop ships none), TCC refused the request before
+  EventKit was reached and no prompt ever appeared. The server now spawns
+  `bin/event` through a new `bin/event-disclaim` shim (compiled from
+  `scripts/disclaim.c`) that disclaims TCC responsibility at spawn time —
+  the same mechanism Chromium and LLDB use — making `event` its own
+  responsible process. `event` now embeds an Info.plist
+  (`scripts/event-Info.plist`, bundle id `me.frad.event`) with all six
+  Reminders/Calendar usage strings and is signed with the
+  `com.apple.security.personal-information.{calendars,reminders}`
+  entitlements (`scripts/event.entitlements`).
+
+  **Upgrade note:** the permission prompt and the entry in
+  `System Settings > Privacy & Security` now belong to `event`, not to the
+  host app — approve the new prompt once. Grants previously given to
+  Terminal / Claude Desktop no longer cover the MCP server.
+
 ## [1.5.0] - 2026-05-14
 
 ### Changed (BREAKING)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,7 +132,7 @@ return handleAsyncOperation(async () => {
 - Tests use Jest with ts-jest ESM preset
 - Mock the CLI executor in `src/utils/__mocks__/eventCli.ts` (`jest.mock('./eventCli.js')`)
 - Coverage thresholds live in `jest.config.mjs` (currently 93/78/96/94 statements/branches/functions/lines)
-- `src/__tests__/build-event.test.ts` pins the contract of `scripts/build-event.mjs` (calls `swift build -c release`, copies to `bin/event`, signs with `--options runtime`, no `--entitlements`)
+- `src/__tests__/build-event.test.ts` pins the contract of `scripts/build-event.mjs` (calls `swift build -c release` with the `__info_plist` sectcreate flags, copies to `bin/event`, compiles `bin/event-disclaim`, signs with `--options runtime`; `event` gets `--entitlements scripts/event.entitlements`, the shim gets none)
 - `src/utils/projectUtils.ts` is excluded from coverage (import.meta.url incompatible with Jest)
 
 ### Notes Field Conventions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,9 +67,13 @@ src/
 
 The vendored `event` Swift CLI lives at `vendor/event/` (git submodule pinned to
 a specific FradSer/event SHA). `scripts/build-event.mjs` compiles it via
-`swift build -c release`, copies the result to `bin/event`, and signs the
-binary with hardened runtime so macOS 26+ TCC can attribute permission
-dialogs to the host GUI app (e.g. Claude Desktop).
+`swift build -c release` with `scripts/event-Info.plist` linked into the
+`__TEXT,__info_plist` section, copies the result to `bin/event`, compiles the
+TCC disclaim shim `scripts/disclaim.c` to `bin/event-disclaim`, and signs both
+with hardened runtime — `event` additionally with the
+`com.apple.security.personal-information.{calendars,reminders}` entitlements
+(`scripts/event.entitlements`) so it can request EventKit access as its own
+TCC-responsible process.
 
 ### Data Flow
 
@@ -83,7 +87,9 @@ dialogs to the host GUI app (e.g. Claude Desktop).
 
 ### Permission Handling
 
-The `event` CLI requests EventKit permissions via the native async APIs (`requestFullAccessToReminders` / `requestFullAccessToEvents`). When access is denied, restricted, or write-only, it emits an `Error: Permission denied: …` line on stderr; `eventCli.ts` maps that into a domain-typed `CliPermissionError` (`'reminders'` or `'calendars'`) which the host surfaces verbatim. There is no embedded Info.plist on the binary — permission prompts are attributed to the host process (e.g. Claude Desktop) per the macOS 26+ TCC model.
+The `event` CLI requests EventKit permissions via the native async APIs (`requestFullAccessToReminders` / `requestFullAccessToEvents`). When access is denied, restricted, or write-only, it emits an `Error: Permission denied: …` line on stderr; `eventCli.ts` maps that into a domain-typed `CliPermissionError` (`'reminders'` or `'calendars'`) which the host surfaces verbatim.
+
+`eventCli.ts` spawns `bin/event` through the `bin/event-disclaim` shim (falling back to a direct spawn when the shim is absent). The shim disclaims TCC responsibility at spawn time (the same private `responsibility_spawnattrs_setdisclaim` API Chromium and LLDB use), so `event` — which embeds its usage strings in an Info.plist section and carries the personal-information entitlements — is its own TCC-responsible process. Permission prompts are therefore attributed to `event` itself and work from any MCP client, including desktop apps that declare no EventKit usage strings (issue #93).
 
 ### Swift Bridge
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -45,7 +45,7 @@ The server exposes 5 main tools:
 5.  **`reminders_subtasks`**: Manages subtasks/checklists within reminders (create, read, update, delete, toggle, reorder).
 
 ## Permission Handling
-The vendored `event` CLI requests EventKit permissions via the native async APIs (`requestFullAccessToReminders` / `requestFullAccessToEvents`). When access is denied / restricted / write-only it emits `Error: Permission denied: …` on stderr; `src/utils/eventCli.ts` maps that into a domain-typed `CliPermissionError` (`reminders` or `calendars`). Permission prompts are attributed to whichever host process spawns `bin/event` (Claude Desktop, Cursor, etc.) — the binary itself carries no embedded Info.plist.
+The vendored `event` CLI requests EventKit permissions via the native async APIs (`requestFullAccessToReminders` / `requestFullAccessToEvents`). When access is denied / restricted / write-only it emits `Error: Permission denied: …` on stderr; `src/utils/eventCli.ts` maps that into a domain-typed `CliPermissionError` (`reminders` or `calendars`). `bin/event` is spawned through the `bin/event-disclaim` TCC shim (falling back to a direct, host-attributed spawn when the shim is absent), so permission prompts are attributed to `event` itself (it embeds an Info.plist with the EventKit usage strings) rather than to the host MCP client (issue #93).
 
 ## Critical Constraints
 *   **macOS Only**: Strictly requires macOS with the EventKit framework.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The published npm package ships a pre-built, universal, code-signed `bin/event` 
 
 ## macOS Permission Requirements (Sonoma 14+ / Sequoia 15)
 
-Apple separates Reminders and Calendar permissions into _write-only_ and _full-access_ scopes. The vendored `event` CLI does not embed its own Info.plist — permission prompts are attributed to whichever host process spawns it (Claude Desktop, Cursor, Terminal, etc.), so the host application's bundle is what needs to declare the privacy strings:
+Apple separates Reminders and Calendar permissions into _write-only_ and _full-access_ scopes. The vendored `event` CLI embeds its own Info.plist (bundle id `me.frad.event`) declaring all the privacy strings:
 
 - `NSRemindersUsageDescription`
 - `NSRemindersFullAccessUsageDescription`
@@ -79,9 +79,11 @@ Apple separates Reminders and Calendar permissions into _write-only_ and _full-a
 - `NSCalendarsFullAccessUsageDescription`
 - `NSCalendarsWriteOnlyAccessUsageDescription`
 
+The MCP server spawns `event` through the bundled `bin/event-disclaim` shim, which disclaims TCC responsibility at spawn time — so macOS attributes the permission request to `event` itself, not to whichever app launched the MCP server. The first EventKit call therefore shows a prompt for **"event"**, and the grant appears under `System Settings > Privacy & Security > Reminders / Calendars` as `event`. One grant covers every MCP client on the machine (Claude Desktop, Codex Desktop, Cursor, terminal clients, …).
+
 When the CLI detects a `notDetermined` authorization status it calls `requestFullAccessToReminders` / `requestFullAccessToEvents`, which triggers macOS to show the correct prompt. If the OS ever loses track of permissions, rerun `./check-permissions.sh` to re-open the dialogs.
 
-If a Claude tool call still encounters a permission failure, see *Desktop MCP clients* below for the responsible-process attribution problem and the recommended workarounds.
+If a Claude tool call still encounters a permission failure, see *Desktop MCP clients* below.
 
 ### Troubleshooting Calendar Read Errors
 
@@ -95,33 +97,19 @@ You can also re-run `./check-permissions.sh` (it validates both Reminders and Ca
 
 ### Desktop MCP clients (Claude Desktop, Codex Desktop, …)
 
-macOS attributes Reminders and Calendar access to the **responsible** process — the desktop app that launched the MCP server, not the `event` subprocess. For the EventKit prompt to appear, the responsible app's bundle must ship the `NSRemindersUsageDescription` / `NSCalendarsUsageDescription` keys (and on Sonoma+ the matching write-only or full-access variants). If those keys are missing, TCC refuses the request before EventKit is even reached, and the CLI returns:
+macOS attributes Reminders and Calendar access to the **responsible** process. By default that is the desktop app that launched the MCP server, not the `event` subprocess — and if that app's bundle is missing the `NSRemindersUsageDescription` / `NSCalendarsUsageDescription` keys (Codex Desktop ships only `NSAppleEventsUsageDescription`), TCC refuses the request before EventKit is even reached:
 
 ```text
 Reminder permission denied. Unknown error
 ```
 
-— even though running the same binary from Terminal works. See [issue #93](https://github.com/FradSer/mcp-server-apple-events/issues/93) for the full TCC log; Codex Desktop today ships only `NSAppleEventsUsageDescription`, which is why it hits this wall.
+Since the fix for [issue #93](https://github.com/FradSer/mcp-server-apple-events/issues/93), this server breaks that attribution chain itself: `bin/event` is always spawned through the `bin/event-disclaim` shim, which uses the same responsibility-disclaim spawn attribute as Chromium and LLDB, so `event` becomes its own TCC-responsible process. `event` embeds the required usage strings and is signed with the `com.apple.security.personal-information.{reminders,calendars}` hardened-runtime entitlements, so the EventKit prompt appears no matter which desktop client launched the server.
 
-This is a macOS-level constraint that an MCP server alone cannot resolve — the desktop client itself needs to declare those usage strings in its `Info.plist`. The workarounds below are about making the server *usable* while you wait for the upstream fix:
+Notes after upgrading:
 
-**Reliable workaround — run the server from a terminal-based MCP client.** Codex CLI, Claude Code, and similar terminal-launched clients inherit Terminal's (or iTerm2's) own `kTCCServiceReminders` / `kTCCServiceCalendar` grant, so EventKit calls succeed without changes to this server:
-
-```bash
-# from inside Terminal / iTerm2, where the responsible app holds the EventKit grants
-codex
-# or
-claude
-```
-
-**Partial workaround — AppleScript routing (only if the desktop app already declares `NSAppleEventsUsageDescription`).** Running:
-
-```bash
-osascript -e 'tell application "Reminders" to get name of lists'
-osascript -e 'tell application "Calendar" to get name of calendars'
-```
-
-triggers an **Automation** prompt (`kTCCServiceAppleEvents`) so the responsible app can control `com.apple.reminders` and `com.apple.iCal`. This does *not* create a `kTCCServiceReminders` / `kTCCServiceCalendar` grant on its own, so a Swift CLI that calls EventKit directly will still be refused if the host bundle is missing the usage strings. It only helps if your client can fall back to AppleScript end-to-end (this server does not today).
+- The permission prompt (and the entry in `System Settings > Privacy & Security`) is now for **`event`**, not for Terminal / Claude Desktop / Codex Desktop. Existing grants made to those host apps no longer apply to the MCP server; approve the new `event` prompt once.
+- With an ad-hoc (local) build, macOS keys the grant to the exact binary hash — rebuilding `bin/event` re-prompts. Prebuilt npm releases are Developer ID-signed, so the grant is stable across updates. Local builds can set `APPLE_SIGNING_IDENTITY` for the same stability.
+- Running `./bin/event` directly (without the shim) still uses host attribution, so direct Terminal use keeps working exactly as before via Terminal's own grant.
 
 **Verification command**
 
@@ -129,7 +117,7 @@ triggers an **Automation** prompt (`kTCCServiceAppleEvents`) so the responsible 
 pnpm test -- src/__tests__/build-event.test.ts
 ```
 
-This pins the contract of `scripts/build-event.mjs` — the build compiles `vendor/event` once per architecture (arm64 + x86_64) via `swift build -c release`, merges the two with `lipo` into a universal `bin/event`, and code-signs it (Developer ID Application certificate when available, ad-hoc fallback otherwise) with hardened runtime.
+This pins the contract of `scripts/build-event.mjs` — the build compiles `vendor/event` once per architecture (arm64 + x86_64) via `swift build -c release` with the Info.plist linked into the `__TEXT,__info_plist` section, merges the two with `lipo` into a universal `bin/event`, compiles the `bin/event-disclaim` shim from `scripts/disclaim.c`, and code-signs both (Developer ID Application certificate when available, ad-hoc fallback otherwise) with hardened runtime — `event` additionally with the personal-information entitlements.
 
 ### Troubleshooting `could not build module 'Foundation'` on macOS 26 (Tahoe)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -70,7 +70,7 @@ npm 发布包自带预构建的通用签名 `bin/event` 二进制，使用 `npx`
 
 ## macOS 权限要求（Sonoma 14+ / Sequoia 15）
 
-Apple 将提醒事项和日历权限拆分为「仅写入」与「完全访问」范围。vendor 的 `event` CLI 没有内嵌 Info.plist——权限提示归属于启动它的宿主进程（Claude Desktop、Cursor、Terminal 等），因此需要由宿主应用的 bundle 声明这些隐私键：
+Apple 将提醒事项和日历权限拆分为「仅写入」与「完全访问」范围。vendored 的 `event` CLI 内嵌了自己的 Info.plist（bundle id 为 `me.frad.event`），声明了以下隐私键：
 
 - `NSRemindersUsageDescription`
 - `NSRemindersFullAccessUsageDescription`
@@ -79,9 +79,11 @@ Apple 将提醒事项和日历权限拆分为「仅写入」与「完全访问�
 - `NSCalendarsFullAccessUsageDescription`
 - `NSCalendarsWriteOnlyAccessUsageDescription`
 
+MCP 服务通过随附的 `bin/event-disclaim` shim 启动 `event`，在 spawn 时主动放弃（disclaim）TCC 责任归属——macOS 因此会把权限请求归到 `event` 自己头上，而不是启动 MCP 服务的宿主应用。首次调用 EventKit 时弹出的授权对话框显示的是 **“event”**，授权记录也以 `event` 的名义出现在 `系统设置 > 隐私与安全性 > 提醒事项 / 日历` 中。授权一次即可覆盖本机上所有 MCP 客户端（Claude Desktop、Codex Desktop、Cursor、终端客户端等）。
+
 当 CLI 检测到 `notDetermined` 授权状态时，会调用 `requestFullAccessToReminders` / `requestFullAccessToEvents`，macOS 会弹出对应的授权对话框。如果系统遗失权限记录，可运行 `./check-permissions.sh` 重新触发请求。
 
-若 Claude 的工具调用依旧遇到权限错误，请参阅下方的 *桌面端 MCP 客户端* 一节——那里描述了 responsible 进程归属问题以及推荐的解决方案。
+若 Claude 的工具调用依旧遇到权限错误，请参阅下方的 *桌面端 MCP 客户端* 一节。
 
 ### 日历读取报错排查
 
@@ -95,33 +97,19 @@ Apple 将提醒事项和日历权限拆分为「仅写入」与「完全访问�
 
 ### 桌面端 MCP 客户端（Claude Desktop、Codex Desktop 等）
 
-macOS 把提醒事项与日历的访问权限归属到 **responsible（负责）** 进程——也就是启动 MCP 服务的桌面应用本身，而不是 `event` 子进程。要让 EventKit 弹出授权对话框，负责应用的 bundle 必须在自己的 `Info.plist` 中声明 `NSRemindersUsageDescription` / `NSCalendarsUsageDescription`（macOS Sonoma 之后还需要写入权限或完全访问权限的对应键）。如果这些键缺失，TCC 会在请求到达 EventKit 之前就拒绝它，CLI 会返回：
+macOS 会把提醒事项与日历的访问权限归属到 **responsible（负责）** 进程。默认情况下，负责进程是启动 MCP 服务的桌面应用本身，而不是 `event` 子进程——如果该应用的 bundle 缺少 `NSRemindersUsageDescription` / `NSCalendarsUsageDescription`（Codex Desktop 只声明了 `NSAppleEventsUsageDescription`），TCC 会在请求到达 EventKit 之前就拒绝它：
 
 ```text
 Reminder permission denied. Unknown error
 ```
 
-——即使同一个二进制在 Terminal 中可以正常工作。完整的 TCC 日志见 [issue #93](https://github.com/FradSer/mcp-server-apple-events/issues/93)。目前 Codex Desktop 只声明了 `NSAppleEventsUsageDescription`，这就是它会撞到这堵墙的原因。
+自 [issue #93](https://github.com/FradSer/mcp-server-apple-events/issues/93) 修复之后，本服务自己打破了这条归属链：`bin/event` 始终经由 `bin/event-disclaim` shim 启动，shim 使用与 Chromium、LLDB 相同的 responsibility-disclaim spawn 属性，让 `event` 成为自己的 TCC 负责进程。`event` 内嵌了所需的 usage description，并以 `com.apple.security.personal-information.{reminders,calendars}` hardened-runtime entitlements 签名，因此无论哪个桌面客户端启动本服务，EventKit 授权对话框都能正常弹出。
 
-这是 macOS 层面的限制，单凭 MCP 服务无法绕过——只有桌面客户端自己在 `Info.plist` 里加上对应的 usage description 才能根治。在等待上游修复期间，下面的两个方案能让本服务保持可用：
+升级后的注意事项：
 
-**可靠方案——使用基于终端的 MCP 客户端启动本服务。** Codex CLI、Claude Code 等在终端中启动的客户端会继承 Terminal / iTerm2 已经持有的 `kTCCServiceReminders` / `kTCCServiceCalendar` 授权，本服务无需修改即可正常调用 EventKit：
-
-```bash
-# 在 Terminal / iTerm2 里运行，由它充当 responsible app
-codex
-# 或
-claude
-```
-
-**部分方案——AppleScript 路由（仅当桌面应用已声明 `NSAppleEventsUsageDescription` 时有效）。** 运行：
-
-```bash
-osascript -e 'tell application "Reminders" to get name of lists'
-osascript -e 'tell application "Calendar" to get name of calendars'
-```
-
-会触发一次 **Automation** 授权请求（`kTCCServiceAppleEvents`），允许负责应用控制 `com.apple.reminders` 与 `com.apple.iCal`。但这并不会顺带创建 `kTCCServiceReminders` / `kTCCServiceCalendar` 授权记录，所以一个直接调用 EventKit 的 Swift CLI 在 host bundle 缺少 usage description 时仍然会被拒。只有当你的客户端能够端到端走 AppleScript 时这套方案才生效（本服务目前并不会这么做）。
+- 授权对话框（以及 `系统设置 > 隐私与安全性` 中的条目）现在归属于 **`event`**，而不是 Terminal / Claude Desktop / Codex Desktop。之前授予这些宿主应用的权限不再作用于 MCP 服务；`event` 的新授权请求批准一次即可。
+- 使用 ad-hoc（本地）构建时，macOS 会将授权绑定到二进制的精确哈希——重新构建 `bin/event` 会再次弹窗。npm 预编译发行版使用 Developer ID 签名，授权可跨版本保持稳定。本地构建可通过设置 `APPLE_SIGNING_IDENTITY` 获得同样的稳定性。
+- 直接运行 `./bin/event`（不经过 shim）仍然沿用宿主归属，因此在 Terminal 中直接使用的行为与以前完全一致。
 
 **验证命令**
 
@@ -129,7 +117,7 @@ osascript -e 'tell application "Calendar" to get name of calendars'
 pnpm test -- src/__tests__/build-event.test.ts
 ```
 
-该测试用例锁定了 `scripts/build-event.mjs` 的构建契约：分别为 arm64 与 x86_64 两种架构各调用一次 `swift build -c release` 构建 vendored 子模块，用 `lipo` 合并为通用二进制 `bin/event`，并优先使用登录钥匙串中的 Developer ID Application 证书签名（找不到时回退为 ad-hoc 签名并给出警告），全程启用 hardened runtime。
+该测试用例锁定了 `scripts/build-event.mjs` 的构建契约：分别为 arm64 与 x86_64 两种架构各调用一次 `swift build -c release` 构建 vendored 子模块（并把 Info.plist 链接进 `__TEXT,__info_plist` 段），用 `lipo` 合并为通用二进制 `bin/event`，再从 `scripts/disclaim.c` 编译出 `bin/event-disclaim` shim，最后为两个二进制签名（优先使用登录钥匙串中的 Developer ID Application 证书，找不到时回退为 ad-hoc 签名并给出警告），全程启用 hardened runtime，`event` 还额外携带 personal-information entitlements。
 
 ### macOS 26 (Tahoe) 上 `could not build module 'Foundation'` 错误排查
 

--- a/check-permissions.sh
+++ b/check-permissions.sh
@@ -5,40 +5,54 @@
 
 echo "Checking Apple Events MCP Server permissions..."
 
-# Check if running in a GUI app context (not standard terminal)
-PARENT_PID=$(ps -o ppid= -p $$ | xargs)
-if [[ -n "$PARENT_PID" ]]; then
-    CUR=$PARENT_PID
-    while [[ -n "$CUR" && $CUR -gt 1 ]]; do
-        PATH_TO_PID=$(ps -o command= -p $CUR 2>/dev/null | awk '{print $1}')
-        if [[ "$PATH_TO_PID" == *".app/"* ]]; then
-            APP_NAME=$(echo "$PATH_TO_PID" | tr '/' '\n' | grep '\.app$' | head -n 1)
-            if [[ -n "$APP_NAME" ]]; then
-                # Check if it's a known terminal
-                if [[ ! "$APP_NAME" =~ ^(Terminal|iTerm|Warp|Ghostty|WezTerm|Alacritty|kitty)\.app$ ]]; then
-                    echo "================================================================================"
-                    echo "WARNING: Running within GUI context of parent application: $APP_NAME"
-                    echo "macOS TCC (Privacy) attributes permission prompts to $APP_NAME."
-                    echo "If $APP_NAME lacks calendar/reminder usage descriptions or entitlements,"
-                    echo "permission prompts will fail immediately."
-                    echo "WORKAROUND: Run this script directly in a native Terminal window instead."
-                    echo "================================================================================"
-                    echo ""
+# Mirror the MCP server's spawn path: when the event-disclaim TCC shim is
+# present, run `event` through it so the binary is its own TCC-responsible
+# process and the Reminders/Calendar prompt appears even inside GUI MCP
+# clients that ship no EventKit usage strings (issue #93).
+if [[ -x ./bin/event-disclaim ]]; then
+    EVENT=(./bin/event-disclaim ./bin/event)
+else
+    EVENT=(./bin/event)
+fi
+
+# Without the shim, TCC attributes prompts to the parent GUI app — warn when
+# that parent is not a regular terminal.
+if [[ ! -x ./bin/event-disclaim ]]; then
+    PARENT_PID=$(ps -o ppid= -p $$ | xargs)
+    if [[ -n "$PARENT_PID" ]]; then
+        CUR=$PARENT_PID
+        while [[ -n "$CUR" && $CUR -gt 1 ]]; do
+            PATH_TO_PID=$(ps -o command= -p $CUR 2>/dev/null | awk '{print $1}')
+            if [[ "$PATH_TO_PID" == *".app/"* ]]; then
+                APP_NAME=$(echo "$PATH_TO_PID" | tr '/' '\n' | grep '\.app$' | head -n 1)
+                if [[ -n "$APP_NAME" ]]; then
+                    # Check if it's a known terminal
+                    if [[ ! "$APP_NAME" =~ ^(Terminal|iTerm|Warp|Ghostty|WezTerm|Alacritty|kitty)\.app$ ]]; then
+                        echo "================================================================================"
+                        echo "WARNING: Running within GUI context of parent application: $APP_NAME"
+                        echo "macOS TCC (Privacy) attributes permission prompts to $APP_NAME."
+                        echo "If $APP_NAME lacks calendar/reminder usage descriptions or entitlements,"
+                        echo "permission prompts will fail immediately."
+                        echo "FIX: rebuild with 'pnpm build' to produce bin/event-disclaim, or run this"
+                        echo "script from a native Terminal window instead."
+                        echo "================================================================================"
+                        echo ""
+                    fi
                 fi
+                break
             fi
-            break
-        fi
-        NEXT_CUR=$(ps -o ppid= -p $CUR 2>/dev/null | xargs)
-        if [[ "$NEXT_CUR" == "$CUR" ]]; then
-            break
-        fi
-        CUR=$NEXT_CUR
-    done
+            NEXT_CUR=$(ps -o ppid= -p $CUR 2>/dev/null | xargs)
+            if [[ "$NEXT_CUR" == "$CUR" ]]; then
+                break
+            fi
+            CUR=$NEXT_CUR
+        done
+    fi
 fi
 
 # Check EventKit permissions
 echo "Checking EventKit (Reminders) permission..."
-EVENTKIT_CHECK=$(./bin/event reminders list --json 2>&1)
+EVENTKIT_CHECK=$("${EVENT[@]}" reminders list --json 2>&1)
 if [[ $? -eq 0 ]]; then
     echo "EventKit permission granted."
 else
@@ -49,7 +63,7 @@ else
 fi
 
 echo "Checking EventKit (Calendars) permission..."
-CALENDAR_CHECK=$(./bin/event calendar list --json 2>&1)
+CALENDAR_CHECK=$("${EVENT[@]}" calendar list --json 2>&1)
 if [[ $? -eq 0 ]]; then
     echo "Calendar permission granted."
 else

--- a/check-permissions.sh
+++ b/check-permissions.sh
@@ -5,6 +5,37 @@
 
 echo "Checking Apple Events MCP Server permissions..."
 
+# Check if running in a GUI app context (not standard terminal)
+PARENT_PID=$(ps -o ppid= -p $$ | xargs)
+if [[ -n "$PARENT_PID" ]]; then
+    CUR=$PARENT_PID
+    while [[ -n "$CUR" && $CUR -gt 1 ]]; do
+        PATH_TO_PID=$(ps -o command= -p $CUR 2>/dev/null | awk '{print $1}')
+        if [[ "$PATH_TO_PID" == *".app/"* ]]; then
+            APP_NAME=$(echo "$PATH_TO_PID" | tr '/' '\n' | grep '\.app$' | head -n 1)
+            if [[ -n "$APP_NAME" ]]; then
+                # Check if it's a known terminal
+                if [[ ! "$APP_NAME" =~ ^(Terminal|iTerm|Warp|Ghostty|WezTerm|Alacritty|kitty)\.app$ ]]; then
+                    echo "================================================================================"
+                    echo "WARNING: Running within GUI context of parent application: $APP_NAME"
+                    echo "macOS TCC (Privacy) attributes permission prompts to $APP_NAME."
+                    echo "If $APP_NAME lacks calendar/reminder usage descriptions or entitlements,"
+                    echo "permission prompts will fail immediately."
+                    echo "WORKAROUND: Run this script directly in a native Terminal window instead."
+                    echo "================================================================================"
+                    echo ""
+                fi
+            fi
+            break
+        fi
+        NEXT_CUR=$(ps -o ppid= -p $CUR 2>/dev/null | xargs)
+        if [[ "$NEXT_CUR" == "$CUR" ]]; then
+            break
+        fi
+        CUR=$NEXT_CUR
+    done
+fi
+
 # Check EventKit permissions
 echo "Checking EventKit (Reminders) permission..."
 EVENTKIT_CHECK=$(./bin/event reminders list --json 2>&1)

--- a/check-permissions.sh
+++ b/check-permissions.sh
@@ -22,7 +22,9 @@ if [[ ! -x ./bin/event-disclaim ]]; then
     if [[ -n "$PARENT_PID" ]]; then
         CUR=$PARENT_PID
         while [[ -n "$CUR" && $CUR -gt 1 ]]; do
-            PATH_TO_PID=$(ps -o command= -p $CUR 2>/dev/null | awk '{print $1}')
+            # `comm=` returns the executable path without arguments, so app
+            # paths containing spaces (e.g. "Claude Desktop.app") stay intact.
+            PATH_TO_PID=$(ps -o comm= -p $CUR 2>/dev/null)
             if [[ "$PATH_TO_PID" == *".app/"* ]]; then
                 APP_NAME=$(echo "$PATH_TO_PID" | tr '/' '\n' | grep '\.app$' | head -n 1)
                 if [[ -n "$APP_NAME" ]]; then

--- a/package.json
+++ b/package.json
@@ -28,9 +28,13 @@
   },
   "files": [
     "bin/event",
+    "bin/event-disclaim",
     "dist/",
     "scripts/postinstall.mjs",
     "scripts/build-event.mjs",
+    "scripts/event-Info.plist",
+    "scripts/event.entitlements",
+    "scripts/disclaim.c",
     "CHANGELOG.md"
   ],
   "engines": {

--- a/scripts/build-event.mjs
+++ b/scripts/build-event.mjs
@@ -274,6 +274,40 @@ async function main() {
 
   let builtBinaries;
   try {
+    // Ask SwiftPM for the actual release output directory per slice instead
+    // of assuming a `.build/<triple>/release` layout, since that convention
+    // is not a stable public contract.
+    builtBinaries = await Promise.all(
+      slices.map(async (s) => {
+        const { stdout: binPathOut } = await run(
+          'swift',
+          [
+            'build',
+            '--show-bin-path',
+            '-c',
+            'release',
+            '--package-path',
+            eventPackagePath,
+            '--scratch-path',
+            s.scratchPath,
+            '--triple',
+            s.triple,
+          ],
+          { env: gitEnv },
+        );
+        return path.join(binPathOut.trim(), 'event');
+      }),
+    );
+
+    // SwiftPM's incremental build does not track the -sectcreate Info.plist
+    // as a link input, so editing scripts/event-Info.plist alone would leave
+    // a stale plist embedded in the cached executable. Deleting the slice
+    // outputs forces a relink (object files stay cached — this costs seconds,
+    // not a rebuild).
+    await Promise.all(
+      slices.map((_, i) => fs.rm(builtBinaries[i], { force: true })),
+    );
+
     // Slices are independent — build in parallel to roughly halve build time.
     const results = await Promise.all(
       slices.map((s) =>
@@ -312,31 +346,6 @@ async function main() {
       if (stderr) console.warn(`${slices[i].label} build warnings:\n${stderr}`);
       if (stdout) console.log(stdout);
     });
-
-    // Ask SwiftPM for the actual release output directory per slice instead
-    // of assuming a `.build/<triple>/release` layout, since that convention
-    // is not a stable public contract.
-    builtBinaries = await Promise.all(
-      slices.map(async (s) => {
-        const { stdout: binPathOut } = await run(
-          'swift',
-          [
-            'build',
-            '--show-bin-path',
-            '-c',
-            'release',
-            '--package-path',
-            eventPackagePath,
-            '--scratch-path',
-            s.scratchPath,
-            '--triple',
-            s.triple,
-          ],
-          { env: gitEnv },
-        );
-        return path.join(binPathOut.trim(), 'event');
-      }),
-    );
 
     await run('xcrun', [
       'lipo',

--- a/scripts/build-event.mjs
+++ b/scripts/build-event.mjs
@@ -204,6 +204,11 @@ async function main() {
   const eventPackageManifest = path.join(eventPackagePath, 'Package.swift');
   const binDir = path.join(projectRoot, 'bin');
   const outputFile = path.join(binDir, 'event');
+  const scriptsDir = path.join(projectRoot, 'scripts');
+  const infoPlistFile = path.join(scriptsDir, 'event-Info.plist');
+  const entitlementsFile = path.join(scriptsDir, 'event.entitlements');
+  const disclaimSourceFile = path.join(scriptsDir, 'disclaim.c');
+  const disclaimOutputFile = path.join(binDir, 'event-disclaim');
 
   // Run the independent pre-flight checks (toolchain probe, manifest access,
   // bin dir creation) concurrently so `pnpm install`'s postinstall hook
@@ -284,6 +289,20 @@ async function main() {
             s.scratchPath,
             '--triple',
             s.triple,
+            // Embed the Info.plist (bundle id + EventKit usage strings) into
+            // the executable so TCC can prompt for `event` itself when the
+            // binary is spawned disclaimed (see scripts/disclaim.c). A bare
+            // Mach-O has no bundle, so the plist rides in the __info_plist
+            // section of __TEXT — the documented location TCC reads for
+            // command-line tools.
+            '-Xlinker',
+            '-sectcreate',
+            '-Xlinker',
+            '__TEXT',
+            '-Xlinker',
+            '__info_plist',
+            '-Xlinker',
+            infoPlistFile,
           ],
           { env: gitEnv },
         ),
@@ -343,6 +362,35 @@ async function main() {
   await fs.chmod(outputFile, '755');
   console.log('Binary is now executable.');
 
+  // Compile the disclaim shim (scripts/disclaim.c). It posix_spawns `event`
+  // with TCC responsibility disclaimed, so the Reminders/Calendar permission
+  // prompt is attributed to `event` itself (which ships the usage strings
+  // above) instead of the desktop MCP client that launched the server —
+  // clients like Codex Desktop declare no EventKit usage strings, and TCC
+  // refuses the request outright when they are the responsible process
+  // (issue #93). clang emits a universal Mach-O directly from repeated
+  // -arch flags; the deployment target matches `event`'s macosx14.0 triples.
+  try {
+    await run('xcrun', [
+      'clang',
+      '-O2',
+      '-mmacosx-version-min=14.0',
+      '-arch',
+      'arm64',
+      '-arch',
+      'x86_64',
+      '-o',
+      disclaimOutputFile,
+      disclaimSourceFile,
+    ]);
+    await fs.chmod(disclaimOutputFile, '755');
+    console.log(`Disclaim shim saved to ${disclaimOutputFile}`);
+  } catch (error) {
+    console.error('Disclaim shim compilation failed!');
+    console.error(error);
+    process.exit(1);
+  }
+
   const signingIdentity = await resolveSigningIdentity();
   const isAdHoc = signingIdentity === '-';
 
@@ -352,14 +400,18 @@ async function main() {
       : `Signing with Developer ID: ${signingIdentity}`,
   );
 
-  // --options runtime: Hardened Runtime, required on macOS 26+ for the TCC
-  //   system to attribute Reminders/Calendar permission dialogs to the host
-  //   GUI app (e.g. Claude Desktop) that spawned the binary as a subprocess.
+  // --options runtime: Hardened Runtime, required for notarization and for
+  //   macOS 26+ TCC prompting policy.
   // --timestamp: secure timestamp from Apple CA; included for Developer ID
   //   signatures to ensure long-term validity; omitted for ad-hoc (no CA).
-  // No entitlements file is passed: `event` carries no embedded Info.plist
-  //   of its own; the host process supplies the usage-description strings.
-  try {
+  // --entitlements (event only): hardened-runtime binaries must hold the
+  //   com.apple.security.personal-information.{calendars,reminders}
+  //   entitlements to be allowed to request EventKit access when they are
+  //   the TCC-responsible process (which they are when spawned disclaimed).
+  // --identifier (event only): pinned to the CFBundleIdentifier in
+  //   scripts/event-Info.plist so the TCC grant is recorded under a stable,
+  //   deterministic identity across rebuilds.
+  const signBinary = async (file, extraArgs) => {
     const codesignArgs = [
       '--force',
       '--sign',
@@ -367,7 +419,8 @@ async function main() {
       '--options',
       'runtime',
       ...(isAdHoc ? [] : ['--timestamp']),
-      outputFile,
+      ...extraArgs,
+      file,
     ];
     const { stdout: csOut, stderr: csErr } = await run(
       'codesign',
@@ -379,10 +432,20 @@ async function main() {
     if (csOut) {
       console.log(csOut);
     }
+  };
+
+  try {
+    await signBinary(outputFile, [
+      '--identifier',
+      'me.frad.event',
+      '--entitlements',
+      entitlementsFile,
+    ]);
+    await signBinary(disclaimOutputFile, []);
     console.log(
       isAdHoc
-        ? 'Binary signed (ad-hoc) with hardened runtime.'
-        : 'Binary signed with Developer ID and hardened runtime.',
+        ? 'Binaries signed (ad-hoc) with hardened runtime.'
+        : 'Binaries signed with Developer ID and hardened runtime.',
     );
   } catch (error) {
     console.error('codesign failed!');

--- a/scripts/disclaim.c
+++ b/scripts/disclaim.c
@@ -1,0 +1,61 @@
+/*
+ * disclaim.c — TCC responsibility disclaim shim (issue #93).
+ *
+ * Usage: event-disclaim <binary> [args...]
+ *
+ * Re-execs <binary> via posix_spawn with POSIX_SPAWN_SETEXEC and TCC
+ * responsibility disclaimed, making <binary> its own TCC-responsible
+ * process. macOS then reads the EventKit usage strings from <binary>'s
+ * embedded Info.plist and can show the Reminders/Calendar permission
+ * prompt even when the process tree was started by a GUI MCP client
+ * (Codex Desktop, Claude Desktop, ...) that declares no such strings —
+ * without the disclaim, TCC attributes the request to that client and
+ * refuses it before EventKit is reached.
+ *
+ * POSIX_SPAWN_SETEXEC replaces this process image in place (exec
+ * semantics), so stdio, exit codes, and signals need no proxying.
+ */
+#include <spawn.h>
+#include <stdio.h>
+#include <string.h>
+
+extern char **environ;
+
+/*
+ * Private libSystem API (macOS 10.14+), the same call Chromium uses to make
+ * helper processes self-responsible for TCC. Declared weakly so the shim
+ * degrades to a plain exec — the pre-shim, host-attributed behavior — if a
+ * future macOS removes the symbol.
+ */
+extern int responsibility_spawnattrs_setdisclaim(posix_spawnattr_t *attrs,
+                                                 int disclaim)
+    __attribute__((weak_import));
+
+int main(int argc, char *argv[]) {
+  if (argc < 2) {
+    fprintf(stderr, "usage: %s <binary> [args...]\n",
+            argc > 0 ? argv[0] : "event-disclaim");
+    return 64;
+  }
+
+  posix_spawnattr_t attr;
+  int rc = posix_spawnattr_init(&attr);
+  if (rc != 0) {
+    fprintf(stderr, "event-disclaim: posix_spawnattr_init: %s\n",
+            strerror(rc));
+    return 127;
+  }
+  posix_spawnattr_setflags(&attr, POSIX_SPAWN_SETEXEC);
+  if (responsibility_spawnattrs_setdisclaim) {
+    responsibility_spawnattrs_setdisclaim(&attr, 1);
+  }
+
+  pid_t pid;
+  rc = posix_spawn(&pid, argv[1], NULL, &attr, &argv[1], environ);
+  /* Reached only when the spawn itself failed — with SETEXEC a successful
+     spawn never returns. */
+  posix_spawnattr_destroy(&attr);
+  fprintf(stderr, "event-disclaim: failed to exec %s: %s\n", argv[1],
+          strerror(rc));
+  return 127;
+}

--- a/scripts/disclaim.c
+++ b/scripts/disclaim.c
@@ -45,7 +45,15 @@ int main(int argc, char *argv[]) {
             strerror(rc));
     return 127;
   }
-  posix_spawnattr_setflags(&attr, POSIX_SPAWN_SETEXEC);
+  rc = posix_spawnattr_setflags(&attr, POSIX_SPAWN_SETEXEC);
+  if (rc != 0) {
+    /* Without SETEXEC, posix_spawn would fork instead of exec-replacing
+       this process — fail loudly rather than leave a confusing parent. */
+    posix_spawnattr_destroy(&attr);
+    fprintf(stderr, "event-disclaim: posix_spawnattr_setflags: %s\n",
+            strerror(rc));
+    return 127;
+  }
   if (responsibility_spawnattrs_setdisclaim) {
     responsibility_spawnattrs_setdisclaim(&attr, 1);
   }

--- a/scripts/event-Info.plist
+++ b/scripts/event-Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleIdentifier</key>
+	<string>me.frad.event</string>
+	<key>CFBundleName</key>
+	<string>event</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSRemindersUsageDescription</key>
+	<string>The event CLI reads and updates your reminders on behalf of the Apple Events MCP server.</string>
+	<key>NSRemindersFullAccessUsageDescription</key>
+	<string>The event CLI reads and updates your reminders on behalf of the Apple Events MCP server.</string>
+	<key>NSRemindersWriteOnlyAccessUsageDescription</key>
+	<string>The event CLI creates reminders on behalf of the Apple Events MCP server.</string>
+	<key>NSCalendarsUsageDescription</key>
+	<string>The event CLI reads and updates your calendar events on behalf of the Apple Events MCP server.</string>
+	<key>NSCalendarsFullAccessUsageDescription</key>
+	<string>The event CLI reads and updates your calendar events on behalf of the Apple Events MCP server.</string>
+	<key>NSCalendarsWriteOnlyAccessUsageDescription</key>
+	<string>The event CLI creates calendar events on behalf of the Apple Events MCP server.</string>
+</dict>
+</plist>

--- a/scripts/event-Info.plist
+++ b/scripts/event-Info.plist
@@ -8,8 +8,6 @@
 	<string>event</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
-	<key>CFBundlePackageType</key>
-	<string>APPL</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>NSRemindersUsageDescription</key>

--- a/scripts/event.entitlements
+++ b/scripts/event.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.personal-information.calendars</key>
+	<true/>
+	<key>com.apple.security.personal-information.reminders</key>
+	<true/>
+</dict>
+</plist>

--- a/scripts/notarize.mjs
+++ b/scripts/notarize.mjs
@@ -11,15 +11,19 @@ const __dirname = path.dirname(__filename);
 const projectRoot = path.resolve(__dirname, '..');
 const binDir = path.join(projectRoot, 'bin');
 const outputFile = path.join(binDir, 'event');
+const disclaimFile = path.join(binDir, 'event-disclaim');
+const stagingDir = path.join(binDir, '.notarize-staging');
 const zipFile = path.join(binDir, 'event.zip');
 
 async function main() {
-  try {
-    await fs.access(outputFile, fs.constants.F_OK);
-  } catch {
-    console.error(`Error: Binary not found at ${outputFile}`);
-    console.error('Run `pnpm run build:event` first.');
-    process.exit(1);
+  for (const file of [outputFile, disclaimFile]) {
+    try {
+      await fs.access(file, fs.constants.F_OK);
+    } catch {
+      console.error(`Error: Binary not found at ${file}`);
+      console.error('Run `pnpm run build:event` first.');
+      process.exit(1);
+    }
   }
 
   const appleId = process.env.APPLE_ID;
@@ -51,13 +55,14 @@ async function main() {
   }
 
   console.log('Creating zip archive for notarization...');
-  await execFileAsync('ditto', [
-    '-c',
-    '-k',
-    '--keepParent',
-    outputFile,
-    zipFile,
-  ]);
+  // Stage both binaries into a scratch directory so a single notarytool
+  // submission covers `event` and the `event-disclaim` shim, without
+  // sweeping up any stray files that may be sitting in bin/.
+  await fs.rm(stagingDir, { recursive: true, force: true });
+  await fs.mkdir(stagingDir, { recursive: true });
+  await fs.copyFile(outputFile, path.join(stagingDir, 'event'));
+  await fs.copyFile(disclaimFile, path.join(stagingDir, 'event-disclaim'));
+  await execFileAsync('ditto', ['-c', '-k', stagingDir, zipFile]);
 
   console.log(
     'Submitting to Apple notary service (this may take a few minutes)...',
@@ -91,8 +96,9 @@ async function main() {
       throw error;
     }
   } finally {
-    // Always clean up the zip regardless of outcome
+    // Always clean up the zip and staging dir regardless of outcome
     await fs.unlink(zipFile).catch(() => {});
+    await fs.rm(stagingDir, { recursive: true, force: true }).catch(() => {});
   }
 
   console.log('Notarization response:\n', submissionOutput);

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -28,17 +28,21 @@ async function main() {
     process.exit(0);
   }
 
-  // If the pre-built binary is already present (npm install from published
+  // If the pre-built binaries are already present (npm install from published
   // package), skip the source build entirely — the npm tarball does not
   // include the vendor/event submodule sources, so there is nothing to
-  // build against anyway.
+  // build against anyway. Both `event` and the `event-disclaim` TCC shim
+  // must exist; a clone with a stale pre-shim build rebuilds to pick up the
+  // shim (issue #93).
   const binPath = path.join(projectRoot, 'bin', 'event');
+  const disclaimPath = path.join(projectRoot, 'bin', 'event-disclaim');
   try {
     await fs.access(binPath, fs.constants.X_OK);
-    console.log('Pre-built `event` binary found, skipping source build.');
+    await fs.access(disclaimPath, fs.constants.X_OK);
+    console.log('Pre-built `event` binaries found, skipping source build.');
     process.exit(0);
   } catch {
-    // Binary not present or not executable — proceed to build from source
+    // Binaries not present or not executable — proceed to build from source
   }
 
   await buildEvent();

--- a/src/__tests__/build-event.test.ts
+++ b/src/__tests__/build-event.test.ts
@@ -30,8 +30,57 @@ describe('build-event.mjs code signing', () => {
     expect(buildScript).toMatch(/codesign[\s\S]*?--options[\s\S]*?runtime/);
   });
 
-  it('does not pass --entitlements (event has no embedded Info.plist)', () => {
-    expect(buildScript).not.toMatch(/--entitlements/);
+  it('signs event with the personal-information entitlements file', () => {
+    expect(buildScript).toMatch(/--entitlements/);
+    expect(buildScript).toMatch(/event\.entitlements/);
+  });
+});
+
+describe('build-event.mjs TCC self-attribution (issue #93)', () => {
+  const buildScript = readFileSync(buildScriptPath, 'utf8');
+  const infoPlist = readFileSync(
+    path.resolve(process.cwd(), 'scripts/event-Info.plist'),
+    'utf8',
+  );
+  const entitlements = readFileSync(
+    path.resolve(process.cwd(), 'scripts/event.entitlements'),
+    'utf8',
+  );
+
+  it('embeds the Info.plist into event via -sectcreate __TEXT __info_plist', () => {
+    expect(buildScript).toMatch(/-sectcreate/);
+    expect(buildScript).toMatch(/__info_plist/);
+    expect(buildScript).toMatch(/event-Info\.plist/);
+  });
+
+  it('Info.plist declares a bundle identifier and all EventKit usage strings', () => {
+    expect(infoPlist).toMatch(/CFBundleIdentifier/);
+    expect(infoPlist).toMatch(/NSRemindersUsageDescription/);
+    expect(infoPlist).toMatch(/NSRemindersFullAccessUsageDescription/);
+    expect(infoPlist).toMatch(/NSCalendarsUsageDescription/);
+    expect(infoPlist).toMatch(/NSCalendarsFullAccessUsageDescription/);
+  });
+
+  it('entitlements request personal-information calendars and reminders', () => {
+    expect(entitlements).toMatch(
+      /com\.apple\.security\.personal-information\.calendars/,
+    );
+    expect(entitlements).toMatch(
+      /com\.apple\.security\.personal-information\.reminders/,
+    );
+  });
+
+  it('compiles the disclaim shim from scripts/disclaim.c to bin/event-disclaim', () => {
+    expect(buildScript).toMatch(/disclaim\.c/);
+    expect(buildScript).toMatch(/event-disclaim/);
+  });
+
+  it('builds the shim universal (arm64 + x86_64) and signs it', () => {
+    // clang accepts repeated -arch flags and emits a fat Mach-O directly.
+    expect(buildScript).toMatch(/'-arch',\s*'arm64'/);
+    expect(buildScript).toMatch(/'-arch',\s*'x86_64'/);
+    // The shim is signed without entitlements; only event gets them.
+    expect(buildScript).toMatch(/signBinary\(disclaimOutputFile,\s*\[\]\)/);
   });
 });
 

--- a/src/__tests__/build-event.test.ts
+++ b/src/__tests__/build-event.test.ts
@@ -57,8 +57,10 @@ describe('build-event.mjs TCC self-attribution (issue #93)', () => {
     expect(infoPlist).toMatch(/CFBundleIdentifier/);
     expect(infoPlist).toMatch(/NSRemindersUsageDescription/);
     expect(infoPlist).toMatch(/NSRemindersFullAccessUsageDescription/);
+    expect(infoPlist).toMatch(/NSRemindersWriteOnlyAccessUsageDescription/);
     expect(infoPlist).toMatch(/NSCalendarsUsageDescription/);
     expect(infoPlist).toMatch(/NSCalendarsFullAccessUsageDescription/);
+    expect(infoPlist).toMatch(/NSCalendarsWriteOnlyAccessUsageDescription/);
   });
 
   it('entitlements request personal-information calendars and reminders', () => {

--- a/src/__tests__/notarize.test.ts
+++ b/src/__tests__/notarize.test.ts
@@ -20,9 +20,10 @@ describe('notarize.mjs', () => {
     expect(notarizeScript).toMatch(/process\.exit\(1\)/);
   });
 
-  it('uses ditto to create a zip archive for submission', () => {
+  it('stages both binaries and uses ditto to create a zip archive for submission', () => {
     expect(notarizeScript).toMatch(/execFileAsync\(\s*'ditto'/);
-    expect(notarizeScript).toMatch(/'--keepParent'/);
+    expect(notarizeScript).toMatch(/\.notarize-staging/);
+    expect(notarizeScript).toMatch(/event-disclaim/);
     expect(notarizeScript).toMatch(/event\.zip/);
   });
 

--- a/src/__tests__/postinstall.test.ts
+++ b/src/__tests__/postinstall.test.ts
@@ -9,21 +9,24 @@ const postinstallScriptPath = path.resolve(
 describe('postinstall.mjs skip-if-prebuilt check', () => {
   const postinstallScript = readFileSync(postinstallScriptPath, 'utf8');
 
-  it('checks for a pre-built, executable bin/event before attempting a build', () => {
+  it('checks for pre-built, executable bin/event and bin/event-disclaim before attempting a build', () => {
     expect(postinstallScript).toMatch(
       /path\.join\(\s*projectRoot\s*,\s*'bin'\s*,\s*'event'\s*\)/,
+    );
+    expect(postinstallScript).toMatch(
+      /path\.join\(\s*projectRoot\s*,\s*'bin'\s*,\s*'event-disclaim'\s*\)/,
     );
     expect(postinstallScript).toMatch(/fs\.access\([\s\S]*?constants\.X_OK/);
   });
 
-  it('exits immediately when the pre-built binary is found (npm install path)', () => {
+  it('exits immediately when the pre-built binaries are found (npm install path)', () => {
     expect(postinstallScript).toMatch(
-      /Pre-built `event` binary found, skipping source build\./,
+      /Pre-built `event` binaries found, skipping source build\./,
     );
     expect(postinstallScript).toMatch(/process\.exit\(0\)/);
   });
 
-  it('falls through to a source build only when the binary is missing', () => {
+  it('falls through to a source build only when a binary is missing', () => {
     expect(postinstallScript).toMatch(/await buildEvent\(\)/);
   });
 });

--- a/src/publishedPackage.test.ts
+++ b/src/publishedPackage.test.ts
@@ -98,7 +98,11 @@ describe('published npm tarball', () => {
     const required = [
       'scripts/postinstall.mjs',
       'scripts/build-event.mjs',
+      'scripts/event-Info.plist',
+      'scripts/event.entitlements',
+      'scripts/disclaim.c',
       'bin/event',
+      'bin/event-disclaim',
     ];
 
     it.each(required)('ships %s', (file) => {

--- a/src/utils/binaryValidator.test.ts
+++ b/src/utils/binaryValidator.test.ts
@@ -475,7 +475,7 @@ describe('binaryValidator', () => {
       const config = getEnvironmentBinaryConfig();
 
       expect(config.expectedHash).toBe('prod-hash-value');
-      expect(config.maxFileSize).toBe(50 * 1024 * 1024);
+      expect(config.maxFileSize).toBe(80 * 1024 * 1024);
       expect(config.requireAbsolutePath).toBe(true);
     });
 
@@ -486,7 +486,7 @@ describe('binaryValidator', () => {
       const config = getEnvironmentBinaryConfig();
 
       expect(config.expectedHash).toBeUndefined();
-      expect(config.maxFileSize).toBe(50 * 1024 * 1024);
+      expect(config.maxFileSize).toBe(80 * 1024 * 1024);
     });
   });
 });

--- a/src/utils/binaryValidator.ts
+++ b/src/utils/binaryValidator.ts
@@ -251,7 +251,10 @@ export function getEnvironmentBinaryConfig(): Partial<BinarySecurityConfig> {
   // Production mode - strict validation
   return {
     expectedHash: process.env.SWIFT_BINARY_HASH,
-    maxFileSize: 50 * 1024 * 1024, // 50MB
+    // The universal bin/event sits at ~51.7MB today; 80MB matches the
+    // published-tarball size-sanity bound and leaves room for vendor bumps
+    // without surfacing as a misleading "binary not found" error.
+    maxFileSize: 80 * 1024 * 1024, // 80MB
     requireAbsolutePath: true,
   };
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -15,6 +15,13 @@ export const FILE_SYSTEM = {
 
   /** Swift binary filename — points at the vendored `event` CLI (FradSer/event). */
   SWIFT_BINARY_NAME: 'event',
+
+  /**
+   * TCC disclaim shim filename — spawns `event` as its own TCC-responsible
+   * process so EventKit permission prompts work from desktop MCP clients
+   * that lack usage-description strings (issue #93).
+   */
+  DISCLAIM_BINARY_NAME: 'event-disclaim',
 } as const;
 
 /**

--- a/src/utils/errorHandling.ts
+++ b/src/utils/errorHandling.ts
@@ -14,8 +14,10 @@ const USER_ACTIONABLE_PERMISSION_PATTERNS = [
   /System Settings > Privacy & Security/i,
   /full calendar access/i,
   /full reminder access/i,
-  /subprocess/i,
-  /responsible process/i,
+  // The disclaim shim's own spawn failures (`event-disclaim: …`) are
+  // classified upstream in eventCli.ts as CliUserError; no broad
+  // subprocess/responsible-process patterns here — they would leak
+  // unrelated internal errors past production sanitization.
 ] as const;
 
 function isUserActionablePermissionError(message: string): boolean {

--- a/src/utils/errorHandling.ts
+++ b/src/utils/errorHandling.ts
@@ -14,6 +14,8 @@ const USER_ACTIONABLE_PERMISSION_PATTERNS = [
   /System Settings > Privacy & Security/i,
   /full calendar access/i,
   /full reminder access/i,
+  /subprocess/i,
+  /responsible process/i,
 ] as const;
 
 function isUserActionablePermissionError(message: string): boolean {

--- a/src/utils/eventCli.test.ts
+++ b/src/utils/eventCli.test.ts
@@ -83,9 +83,11 @@ describe('eventCli', () => {
     clearEventBinaryPathCache();
     mockFindProjectRoot.mockReturnValue('/test/project');
     mockGetEnvironmentBinaryConfig.mockReturnValue({});
-    mockFindSecureBinaryPath.mockReturnValue({
-      path: '/test/project/bin/event',
-    });
+    // Default: the `event` binary resolves, the optional disclaim shim does
+    // not — exercising the direct-spawn fallback most tests assert on.
+    mockFindSecureBinaryPath.mockImplementation((paths: string[]) =>
+      paths[0]?.endsWith('/bin/event') ? { path: paths[0] } : { path: null },
+    );
   });
 
   describe('executeEventCliJson — success', () => {
@@ -305,9 +307,6 @@ describe('eventCli', () => {
 
     it('uses findProjectRoot to compute the canonical bin/event path', async () => {
       mockFindProjectRoot.mockReturnValue('/custom/project');
-      mockFindSecureBinaryPath.mockReturnValue({
-        path: '/custom/project/bin/event',
-      });
       respondWith({ stdout: JSON.stringify({ ok: true }) });
 
       await executeEventCliJson(['reminders', 'lists', 'list', '--json']);
@@ -318,6 +317,151 @@ describe('eventCli', () => {
         { maxBuffer: 10 * 1024 * 1024 },
         expect.any(Function),
       );
+    });
+  });
+
+  describe('TCC disclaim shim routing (issue #93)', () => {
+    // Given the build produced bin/event-disclaim next to bin/event,
+    // when any event command runs, then it is spawned through the shim so
+    // the TCC permission prompt is attributed to `event` itself instead of
+    // the desktop MCP client that launched the server.
+    const resolveBoth = () => {
+      mockFindSecureBinaryPath.mockImplementation((paths: string[]) => ({
+        path: paths[0] ?? null,
+      }));
+    };
+
+    it('spawns event through bin/event-disclaim when the shim is present', async () => {
+      resolveBoth();
+      respondWith({ stdout: JSON.stringify({ ok: true }) });
+
+      await executeEventCliJson(['reminders', 'list', '--json']);
+
+      expect(mockExecFile).toHaveBeenCalledWith(
+        '/test/project/bin/event-disclaim',
+        ['/test/project/bin/event', 'reminders', 'list', '--json'],
+        { maxBuffer: 10 * 1024 * 1024 },
+        expect.any(Function),
+      );
+    });
+
+    it('routes plain-text commands through the shim as well', async () => {
+      resolveBoth();
+      respondWith({ stdout: 'Reminder deleted successfully\n' });
+
+      const result = await executeEventCliPlain([
+        'reminders',
+        'delete',
+        '--id',
+        'abc',
+      ]);
+
+      expect(result).toBe('Reminder deleted successfully');
+      expect(mockExecFile).toHaveBeenCalledWith(
+        '/test/project/bin/event-disclaim',
+        ['/test/project/bin/event', 'reminders', 'delete', '--id', 'abc'],
+        { maxBuffer: 10 * 1024 * 1024 },
+        expect.any(Function),
+      );
+    });
+
+    it('falls back to direct spawn when the shim is absent', async () => {
+      // Default beforeEach mock resolves only bin/event.
+      respondWith({ stdout: JSON.stringify({ ok: true }) });
+
+      await executeEventCliJson(['reminders', 'list', '--json']);
+
+      expect(mockExecFile).toHaveBeenCalledWith(
+        '/test/project/bin/event',
+        ['reminders', 'list', '--json'],
+        { maxBuffer: 10 * 1024 * 1024 },
+        expect.any(Function),
+      );
+    });
+
+    it('does not apply the SWIFT_BINARY_HASH pin (meant for event) to the shim', async () => {
+      // If the event hash pin leaked into the shim's validation config, the
+      // shim could never validate on strict-mode installs and the server
+      // would silently fall back to host-attributed spawning.
+      mockGetEnvironmentBinaryConfig.mockReturnValue({
+        expectedHash: 'pin-for-bin-event',
+      });
+      mockFindSecureBinaryPath.mockImplementation((paths: string[]) => ({
+        path: paths[0] ?? null,
+      }));
+      respondWith({ stdout: JSON.stringify({ ok: true }) });
+
+      await executeEventCliJson(['reminders', 'list', '--json']);
+
+      const shimCall = mockFindSecureBinaryPath.mock.calls.find((call) =>
+        (call[0] as string[])[0]?.endsWith('event-disclaim'),
+      );
+      expect(shimCall).toBeDefined();
+      expect(
+        (shimCall?.[1] as { expectedHash?: string }).expectedHash,
+      ).toBeUndefined();
+    });
+
+    it('surfaces shim spawn failures verbatim as user-actionable errors', async () => {
+      resolveBoth();
+      const error = Object.assign(new Error('Command failed'), {
+        code: 127,
+      }) as ExecFileException;
+      respondWith({
+        stdout: '',
+        stderr:
+          'event-disclaim: failed to exec /test/project/bin/event: No such file or directory\n',
+        error,
+      });
+
+      const promise = executeEventCliJson(['reminders', 'list', '--json']);
+
+      await expect(promise).rejects.toThrow(
+        'event-disclaim: failed to exec /test/project/bin/event',
+      );
+      await expect(promise).rejects.toMatchObject({ name: 'CliUserError' });
+    });
+
+    it('warns on stderr once when the shim is unavailable', async () => {
+      const consoleError = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      const originalNodeEnv = process.env.NODE_ENV;
+      // The warning is suppressed under NODE_ENV=test to keep suite output
+      // clean; emulate a production resolve to observe it.
+      process.env.NODE_ENV = 'production';
+      try {
+        // Default beforeEach mock resolves only bin/event.
+        respondWith({ stdout: JSON.stringify({ ok: true }) });
+
+        await executeEventCliJson(['reminders', 'list', '--json']);
+        await executeEventCliJson(['reminders', 'list', '--json']);
+
+        const shimWarnings = consoleError.mock.calls.filter((call) =>
+          String(call[0]).includes('event-disclaim shim not found'),
+        );
+        expect(shimWarnings).toHaveLength(1);
+      } finally {
+        process.env.NODE_ENV = originalNodeEnv;
+        consoleError.mockRestore();
+      }
+    });
+
+    it('maps permission errors identically when spawned through the shim', async () => {
+      resolveBoth();
+      const error = Object.assign(new Error('Command failed'), {
+        code: 1,
+      }) as ExecFileException;
+      respondWith({
+        stdout: '',
+        stderr:
+          'Error: Permission denied: Reminders access was denied. Please grant access in System Settings > Privacy & Security > Reminders.\n',
+        error,
+      });
+
+      await expect(
+        executeEventCliJson(['reminders', 'list', '--json']),
+      ).rejects.toBeInstanceOf(CliPermissionError);
     });
   });
 

--- a/src/utils/eventCli.ts
+++ b/src/utils/eventCli.ts
@@ -30,12 +30,42 @@ interface BinaryFingerprint {
   mtimeMs: number;
   size: number;
 }
-let cachedBinary: { path: string; fingerprint: BinaryFingerprint } | null =
-  null;
+
+/**
+ * How to launch `event`. When the disclaim shim (`bin/event-disclaim`) is
+ * present, `event` is spawned through it so it becomes its own
+ * TCC-responsible process — the EventKit permission prompt then appears
+ * regardless of whether the host MCP client (Codex Desktop, Claude Desktop,
+ * …) declares EventKit usage strings (issue #93). When the shim is absent
+ * (e.g. an older prebuilt install), fall back to spawning `event` directly,
+ * which preserves the pre-shim host-attribution behavior.
+ */
+interface ResolvedLaunch {
+  cliPath: string;
+  disclaimPath: string | null;
+}
+
+// A no-shim launch is cached too (`disclaimFingerprint: null`) and stays
+// valid only while the shim's canonical path remains absent — so a shim that
+// appears after a rebuild is picked up on the next call, and the no-shim
+// path doesn't re-run full validation (which hashes the ~50 MB binary when
+// SWIFT_BINARY_HASH is pinned) on every tool call.
+let cachedLaunch: {
+  launch: ResolvedLaunch;
+  disclaimCanonicalPath: string;
+  cliFingerprint: BinaryFingerprint;
+  disclaimFingerprint: BinaryFingerprint | null;
+} | null = null;
+
+// Emitted once per process so a missing/invalid shim (which silently reverts
+// EventKit prompts to host-app attribution — the issue #93 failure mode) is
+// diagnosable from the host's MCP server logs.
+let warnedShimUnavailable = false;
 
 /** Clears the cached binary path (for testing). */
 export function clearEventBinaryPathCache(): void {
-  cachedBinary = null;
+  cachedLaunch = null;
+  warnedShimUnavailable = false;
 }
 
 const fingerprintFor = (filePath: string): BinaryFingerprint | null => {
@@ -148,6 +178,13 @@ function throwForStderr(stderr: string): never {
   if (!message) {
     throw new Error('event execution failed: unknown error');
   }
+  // The disclaim shim reports its own spawn failures as
+  // `event-disclaim: <detail>` (no "Error: " prefix). Surface them verbatim
+  // as user-actionable errors — otherwise production error formatting
+  // collapses them into a generic "System error occurred".
+  if (message.startsWith('event-disclaim:')) {
+    throw new CliUserError(message);
+  }
   // Only structured "Error: ..." stderr is treated as a user-actionable
   // CliUserError or permission error. Anything else (panics, OS-level
   // failures, etc.) is wrapped so the host surface mentions the `event`
@@ -163,10 +200,14 @@ function throwForStderr(stderr: string): never {
 }
 
 async function runEventCli(
-  cliPath: string,
+  launch: ResolvedLaunch,
   args: string[],
 ): Promise<ExecResult> {
-  const { result, error } = await execFilePromise(cliPath, args);
+  // Route through the disclaim shim when it exists: `event-disclaim <event>
+  // <args…>` re-execs `event` with TCC responsibility disclaimed.
+  const file = launch.disclaimPath ?? launch.cliPath;
+  const argv = launch.disclaimPath ? [launch.cliPath, ...args] : args;
+  const { result, error } = await execFilePromise(file, argv);
   const stderr = bufferToString(result.stderr) ?? '';
 
   if (error) {
@@ -180,17 +221,24 @@ async function runEventCli(
   return result;
 }
 
-function resolveBinaryPathOrThrow(): string {
-  if (
-    cachedBinary &&
-    fingerprintMatches(
-      cachedBinary.fingerprint,
-      fingerprintFor(cachedBinary.path),
-    )
-  ) {
-    return cachedBinary.path;
+function resolveLaunchOrThrow(): ResolvedLaunch {
+  if (cachedLaunch) {
+    const { launch } = cachedLaunch;
+    const cliOk = fingerprintMatches(
+      cachedLaunch.cliFingerprint,
+      fingerprintFor(launch.cliPath),
+    );
+    const disclaimOk = launch.disclaimPath
+      ? fingerprintMatches(
+          cachedLaunch.disclaimFingerprint,
+          fingerprintFor(launch.disclaimPath),
+        )
+      : fingerprintFor(cachedLaunch.disclaimCanonicalPath) === null;
+    if (cliOk && disclaimOk) {
+      return launch;
+    }
   }
-  cachedBinary = null;
+  cachedLaunch = null;
 
   const projectRoot = findProjectRoot();
   const binaryName = FILE_SYSTEM.SWIFT_BINARY_NAME;
@@ -226,11 +274,51 @@ Then use the local path in your Claude Desktop config:
     );
   }
 
-  const fingerprint = fingerprintFor(cliPath);
-  if (fingerprint) {
-    cachedBinary = { path: cliPath, fingerprint };
+  const disclaimCanonicalPath = path.join(
+    projectRoot,
+    'bin',
+    FILE_SYSTEM.DISCLAIM_BINARY_NAME,
+  );
+  const { path: disclaimPath } = findSecureBinaryPath([disclaimCanonicalPath], {
+    ...getEnvironmentBinaryConfig(),
+    // SWIFT_BINARY_HASH pins bin/event, not the shim — carrying it over here
+    // would reject the shim on every strict-mode install and silently revert
+    // to host-attributed prompts. The shim gets its own optional pin.
+    expectedHash: process.env.SWIFT_DISCLAIM_BINARY_HASH,
+    allowedPaths: [disclaimCanonicalPath],
+  });
+
+  if (
+    !disclaimPath &&
+    !warnedShimUnavailable &&
+    process.env.NODE_ENV !== 'test'
+  ) {
+    warnedShimUnavailable = true;
+    console.error(
+      `event-disclaim shim not found or failed validation at ${disclaimCanonicalPath}; ` +
+        'spawning event directly. EventKit permission prompts will be attributed ' +
+        'to the host app instead of event (issue #93). Rebuild with `pnpm build` ' +
+        'to restore the shim.',
+    );
   }
-  return cliPath;
+
+  const launch: ResolvedLaunch = { cliPath, disclaimPath };
+  const cliFingerprint = fingerprintFor(cliPath);
+  const disclaimFingerprint = disclaimPath
+    ? fingerprintFor(disclaimPath)
+    : null;
+  // A shim that resolved but vanished before fingerprinting (race) leaves
+  // disclaimFingerprint null with disclaimPath set — don't cache that; the
+  // next call re-resolves.
+  if (cliFingerprint && (disclaimPath === null || disclaimFingerprint)) {
+    cachedLaunch = {
+      launch,
+      disclaimCanonicalPath,
+      cliFingerprint,
+      disclaimFingerprint,
+    };
+  }
+  return launch;
 }
 
 /**
@@ -251,8 +339,8 @@ Then use the local path in your Claude Desktop config:
  * - Binary path is validated against an allowlist tied to the project root.
  */
 export async function executeEventCliJson<T>(args: string[]): Promise<T> {
-  const cliPath = resolveBinaryPathOrThrow();
-  const { stdout } = await runEventCli(cliPath, args);
+  const launch = resolveLaunchOrThrow();
+  const { stdout } = await runEventCli(launch, args);
   const normalized = bufferToString(stdout);
   if (!normalized) {
     throw new Error('event execution failed: Empty CLI output');
@@ -271,8 +359,8 @@ export async function executeEventCliJson<T>(args: string[]): Promise<T> {
  * `event reminders delete` returns "Reminder deleted successfully").
  */
 export async function executeEventCliPlain(args: string[]): Promise<string> {
-  const cliPath = resolveBinaryPathOrThrow();
-  const { stdout } = await runEventCli(cliPath, args);
+  const launch = resolveLaunchOrThrow();
+  const { stdout } = await runEventCli(launch, args);
   const normalized = bufferToString(stdout) ?? '';
   return normalized.trim();
 }

--- a/src/utils/reminderRepository.test.ts
+++ b/src/utils/reminderRepository.test.ts
@@ -373,7 +373,8 @@ describe('ReminderRepository (event CLI backend)', () => {
         newTitle: 'No completion change',
       });
 
-      const callArgs = mockJson.mock.calls[0][0];
+      expect(mockJson).toHaveBeenCalled();
+      const callArgs = mockJson.mock.calls[0]?.[0] ?? [];
       expect(callArgs).not.toContain('--completed');
     });
 


### PR DESCRIPTION
## Summary

Fixes the root cause of #93: EventKit permission prompts never appeared when this MCP server was launched by a desktop client (Codex Desktop, and any other host that ships no EventKit usage strings). macOS TCC attributes the Reminders/Calendar request to the **responsible process** — the desktop app — and refuses it before EventKit is reached when that app's `Info.plist` lacks `NSRemindersUsageDescription` / `NSCalendarsUsageDescription`.

All previous attempts (embedded Info.plist on the old `EventKitCLI`, hardened runtime in #77, Developer ID signing in #84) changed only the child binary's *signing-time* metadata. Responsibility attribution is a *spawn-time* property, so none of them could work. This PR changes how the binary is spawned.

## What changed

**`event` becomes its own TCC-responsible process:**

- New `scripts/disclaim.c` → compiled to universal `bin/event-disclaim`. It re-execs its target via `posix_spawn` with `POSIX_SPAWN_SETEXEC` plus the private `responsibility_spawnattrs_setdisclaim` attribute — the same mechanism Chromium, LLDB, and Claude Desktop's own `Helpers/disclaimer` use. The symbol is weak-imported, so the shim degrades to a plain exec (pre-fix behavior) if a future macOS removes it.
- `scripts/event-Info.plist` (bundle id `me.frad.event`, all six Reminders/Calendar usage strings) is linked into `bin/event`'s `__TEXT,__info_plist` section.
- `bin/event` is signed with hardened runtime **plus** `com.apple.security.personal-information.{calendars,reminders}` entitlements (`scripts/event.entitlements`) and a pinned `--identifier me.frad.event`, so the TCC grant is recorded under a stable identity (Developer ID builds survive rebuilds).
- `src/utils/eventCli.ts` spawns `event` through the shim whenever `bin/event-disclaim` exists (validated by the same binary allowlist), falling back to a direct spawn for older prebuilt installs.

**Packaging / tooling:**

- `package.json` `files`, `publishedPackage.test.ts`, `postinstall.mjs` (skip-if-prebuilt now requires both binaries), and `notarize.mjs` (one submission covering both binaries) all know about the shim.
- `check-permissions.sh` mirrors the server's spawn path through the shim.
- Docs updated (README, README.zh-CN, CLAUDE.md, AGENTS.md, GEMINI.md, CHANGELOG).

## Verification

- `pnpm check` green: 629 tests / 30 suites, lint, typecheck, coverage thresholds.
- Built artifacts verified: both binaries universal (arm64+x86_64); `otool -s __TEXT __info_plist` shows the embedded plist; `codesign -d --entitlements` shows both personal-information keys; identifier `me.frad.event`, hardened runtime, Developer ID team `GTL29ANKNP`.
- Shim behavior verified: usage error (64), exit-code and stdio passthrough, `event --version` runs through it.
- TCC attribution verified behaviorally: a direct `./bin/event reminders lists list --json` returns instantly via the host terminal's existing grant; the same call through `./bin/event-disclaim` ignores the terminal grant and blocks pending a TCC prompt for `event` itself — no synchronous refusal (the pre-fix Codex Desktop failure mode).

## Upgrade note

The permission prompt (and the entry in System Settings > Privacy & Security) now belongs to **`event`**, not the host app. Users approve it once; the grant then covers every MCP client on the machine. Ad-hoc local builds re-prompt after rebuilds (grant keyed to the binary hash); Developer ID builds are stable.

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fradser/mcp-server-apple-events/pull/110" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the root cause of issue #93: EventKit permission prompts never appeared when the MCP server was launched by desktop clients (Codex Desktop, Claude Desktop) that ship no `NSRemindersUsageDescription` / `NSCalendarsUsageDescription` keys — macOS TCC attributed the request to the host app and refused it silently. The fix is a spawn-time mechanism: a new C shim (`bin/event-disclaim`) re-execs `bin/event` with `POSIX_SPAWN_SETEXEC` and the private `responsibility_spawnattrs_setdisclaim` attribute, making `event` its own TCC-responsible process. `event` now carries a `__TEXT,__info_plist`-embedded plist with all six EventKit usage strings and is signed with the personal-information entitlements.

- **New `bin/event-disclaim` shim** (`scripts/disclaim.c`) uses the same private API as Chromium/LLDB to disclaim TCC responsibility at spawn time; it weak-imports the symbol so it degrades gracefully to a plain exec if the API is ever removed.
- **`src/utils/eventCli.ts`** updated to resolve and cache a `ResolvedLaunch` (shim + event path) instead of just the binary path, with correct cache-invalidation logic for both the shim appearing or disappearing between calls.
- **Build, notarization, postinstall, package, and test files** all updated to treat both binaries as first-class artifacts that must be present and signed.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the TCC disclaim mechanism is correctly implemented, the caching and fallback logic are sound, and previous review comments were properly addressed.

The core spawn-time TCC disclaim is implemented correctly: POSIX_SPAWN_SETEXEC and responsibility_spawnattrs_setdisclaim are used exactly as Chromium uses them, setflags failure is handled loudly per the previous review, and the shim falls back to a plain exec via weak-import if the private API is removed. The TypeScript cache invalidation logic correctly handles the shim appearing or disappearing between calls, hash-pin isolation between the two binaries is explicit, and the test coverage for the new shim-routing path is thorough. The two findings are diagnostic nits in failure paths that do not affect the primary flow.

The responsibility_spawnattrs_setdisclaim return-value check in scripts/disclaim.c and the ps -o comm= detection logic in check-permissions.sh are worth a quick look, but neither affects the happy path.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/disclaim.c | New C shim that re-execs `event` with `POSIX_SPAWN_SETEXEC` and `responsibility_spawnattrs_setdisclaim`; `setflags` error handling was added per previous review but the disclaim API return value is still unchecked. |
| src/utils/eventCli.ts | Cache refactored from single binary path to `ResolvedLaunch`; correctly invalidates on shim appearance/disappearance, separates the shim's hash pin from the event binary's, and surfaces disclaim-shim stderr verbatim as CliUserError. |
| scripts/build-event.mjs | Adds Info.plist `-sectcreate` linker flags to embed the plist, deletes the pre-linked binary to force a relink on every build, compiles the disclaim shim as a universal binary, and signs both artifacts (event with entitlements, shim without). |
| check-permissions.sh | Mirrors the shim-based spawn path for permission checks; the GUI-parent warning in the fallback path uses `ps -o comm=` which on macOS returns the basename, so the `.app/` pattern check is likely ineffective. |
| scripts/event-Info.plist | New plist with CFBundleIdentifier `me.frad.event` and all six EventKit usage strings (base, full-access, write-only for both Reminders and Calendars); embedded via `-sectcreate __TEXT __info_plist`. |
| scripts/event.entitlements | New entitlements file granting `com.apple.security.personal-information.{calendars,reminders}`; required for hardened-runtime binaries acting as their own TCC-responsible process. |
| scripts/notarize.mjs | Updated to copy both binaries into a staging directory and submit them in a single notarytool submission; staging dir is always cleaned up in the `finally` block. |
| scripts/postinstall.mjs | Skip-if-prebuilt guard now requires BOTH `bin/event` and `bin/event-disclaim` to be executable; missing shim triggers a source rebuild to pick it up. |
| src/utils/binaryValidator.ts | Max file size bumped from 50 MB to 80 MB to accommodate the current ~51.7 MB universal binary with embedded plist; leaves room for future vendor bumps. |
| src/utils/eventCli.test.ts | Comprehensive new test suite for the shim-routing path: shim presence, shim absence fallback, hash-pin isolation, shim spawn failure surfacing, once-only warning, and permission-error parity through the shim. |
| src/publishedPackage.test.ts | Required files list extended to include `bin/event-disclaim`, `scripts/event-Info.plist`, `scripts/event.entitlements`, and `scripts/disclaim.c`. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client as Desktop MCP Client
    participant Server as MCP Server (eventCli.ts)
    participant Shim as bin/event-disclaim
    participant Event as bin/event (Swift CLI)
    participant TCC as macOS TCC

    Client->>Server: tool call
    Server->>Server: resolveLaunchOrThrow()
    Server->>Shim: execFile(event-disclaim, [event, ...args])
    Note over Shim: POSIX_SPAWN_SETEXEC + responsibility_spawnattrs_setdisclaim
    Shim->>Event: posix_spawn exec-replace
    Event->>TCC: requestFullAccessToReminders()
    Note over TCC: Reads event __TEXT,__info_plist
    TCC-->>Event: Permission granted (prompt for event)
    Event-->>Server: JSON on stdout
    Server-->>Client: CallToolResult
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client as Desktop MCP Client
    participant Server as MCP Server (eventCli.ts)
    participant Shim as bin/event-disclaim
    participant Event as bin/event (Swift CLI)
    participant TCC as macOS TCC

    Client->>Server: tool call
    Server->>Server: resolveLaunchOrThrow()
    Server->>Shim: execFile(event-disclaim, [event, ...args])
    Note over Shim: POSIX_SPAWN_SETEXEC + responsibility_spawnattrs_setdisclaim
    Shim->>Event: posix_spawn exec-replace
    Event->>TCC: requestFullAccessToReminders()
    Note over TCC: Reads event __TEXT,__info_plist
    TCC-->>Event: Permission granted (prompt for event)
    Event-->>Server: JSON on stdout
    Server-->>Client: CallToolResult
```

</a>

<sub>Reviews (2): Last reviewed commit: ["refactor(utils): narrow error patterns"](https://github.com/fradser/mcp-server-apple-events/commit/a934dd0c84292ca93f316bf25ee431579bfebaf2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42112601)</sub>

<!-- /greptile_comment -->