### PR TITLE
docs: correct un-complete claims for the completed flag

### DIFF
--- a/docs/migration-to-event-cli.md
+++ b/docs/migration-to-event-cli.md
@@ -72,7 +72,7 @@ so values set inside Reminders.app or Calendar.app remain visible.
 | `completionDate` | update | Use `completed: true` to mark complete (timestamp is set by EventKit automatically). |
 | `startDate` | create | Set it via `update` after creation; `update` still accepts `startDate`. |
 | `completed` | create | Create the reminder first, then call `update` with `completed: true`. |
-| `isCompleted: false` | update | Toggle uncompleted state from Reminders.app — `event` cannot un-complete a reminder. |
+| `isCompleted: false` | update | Supported — `--completed false` un-completes (requires `event` CLI >= 0.5.0, commit 564bd4b). |
 | Moving a reminder between lists | update | `event` cannot move reminders between lists. Delete and recreate in the target list, or move from Reminders.app. |
 
 ### `reminders_lists`

--- a/src/utils/reminderRepository.test.ts
+++ b/src/utils/reminderRepository.test.ts
@@ -10,8 +10,9 @@
  *               set (no alarms/recurrence/locationTrigger/location/etc.).
  *   - lists    → `event reminders lists list|create|update|delete` with
  *               name→id resolution for update/delete.
- *   - guards   → cross-list moves and uncomplete attempts must surface a
- *               clean `CliUserError` instead of silently dropping the change.
+ *   - guards   → cross-list moves must surface a clean `CliUserError`
+ *               instead of silently dropping the change (un-completing is
+ *               supported by the CLI and passes straight through).
  */
 
 import type { Reminder, ReminderList } from '../types/index.js';
@@ -378,10 +379,12 @@ describe('ReminderRepository (event CLI backend)', () => {
       expect(callArgs).not.toContain('--completed');
     });
 
-    // Cross-list move + un-complete guards live in handleUpdateReminder
+    // The cross-list move guard lives in handleUpdateReminder
     // (src/tools/handlers/reminderHandlers.ts) so the handler's existing
     // findReminderById fetch is shared with the notes-rebuild path; see
-    // handlers.test.ts for coverage.
+    // handlers.test.ts for coverage. Un-completing (`--completed false`) is
+    // supported by the `event` CLI since v0.5.0 (commit 564bd4b) — the test
+    // above pins the value-passing contract.
   });
 
   describe('deleteReminder', () => {

--- a/src/utils/reminderRepository.ts
+++ b/src/utils/reminderRepository.ts
@@ -240,8 +240,8 @@ class ReminderRepository implements IReminderRepository {
   }
 
   async updateReminder(data: UpdateReminderData): Promise<ReminderJSON> {
-    // Cross-list moves and `isCompleted: false` rejected by the handler so
-    // we share its `findReminderById` fetch with the notes-rebuild path.
+    // Cross-list moves are rejected by the handler, which shares its
+    // `findReminderById` fetch with the notes-rebuild path.
     const args = ['reminders', 'update', '--id', data.id];
     addOptionalArg(args, '--title', data.newTitle);
     addOptionalArg(args, '--notes', data.notes);


### PR DESCRIPTION
## What

Corrects the comments and migration doc that claimed un-completing a reminder is unsupported. The vendored `event` CLI changed `--completed` to an optional boolean in commit `564bd4b` (v0.5.0), already included in the committed submodule pin, so the TS layer's existing `--completed true|false` calls work — verified end-to-end with a create → complete → un-complete → delete round trip.

## Why

Issue #111 reported that `reminders_tasks` update with `{ completed: true }` always failed with "Unexpected argument 'true'" against an older CLI pin that defined `--completed` as a bare flag. The functional fix landed upstream in the pinned CLI; this PR completes it on the repo side by making the docs and comments accurate — the `isCompleted: false` row previously told users to toggle from Reminders.app and cited a non-existent guard.

## Changes

- `docs/migration-to-event-cli.md` — `isCompleted: false` row now documents that `--completed false` un-completes (requires `event` CLI >= 0.5.0, commit `564bd4b`).
- `src/utils/reminderRepository.ts` — comment no longer claims `isCompleted: false` is rejected by the handler; only the cross-list-move guard is documented.
- `src/utils/reminderRepository.test.ts` — header and trailing comments updated to reflect that un-completing passes straight through; the value-passing contract is pinned by existing tests.

No runtime behavior changes.

## Review cycle

1 comment triaged over 1 round, 0 adopted, 0 rejected; all CI green.
Full breakdown: https://github.com/FradSer/mcp-server-apple-events/pull/115#issuecomment-5175455160

## Verification

- `pnpm check` — lint, typecheck, 642 tests across 30 suites, coverage thresholds hold
- `pnpm build` — TS + vendored Swift CLI compile clean
- Manual: `bin/event reminders` create → `--completed true` (isCompleted true) → `--completed false` (isCompleted false) → delete, via the committed-pin binary
