### PR TITLE
feat(app): wire reminders due-date window through the MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Service-scoped tools mirror Apple Reminders and Calendar domains. All take an `a
 
 | Tool | Actions | Notes |
 | --- | --- | --- |
-| `reminders_tasks` | `read`, `create`, `update`, `delete` | Priority, tags, subtasks. `startDate` is set via `update`, not `create`. Cross-list moves unsupported. |
+| `reminders_tasks` | `read`, `create`, `update`, `delete` | Priority, tags, subtasks. `startDate` is set via `update`, not `create`; on `read` it scopes the due-date window alongside `endDate`. Cross-list moves unsupported. |
 | `reminders_subtasks` | `read`, `create`, `update`, `delete`, `toggle`, `reorder` | Stored in the notes field (human-readable in Reminders.app). |
 | `reminders_lists` | `read`, `create`, `update`, `delete` | Rename via `name` → `newName`. |
 | `calendar_events` | `read`, `create`, `update`, `delete` | All-day inferred from date format. Cross-calendar moves unsupported. `span` scopes recurring deletes. |
@@ -194,6 +194,10 @@ Example calls:
 
 ```json
 { "action": "read", "filterList": "Work", "dueWithin": "today", "filterPriority": "high", "filterTags": ["urgent"] }
+```
+
+```json
+{ "action": "read", "startDate": "2026-08-01", "endDate": "2026-08-31" }
 ```
 
 ```json

--- a/src/tools/definitions.test.ts
+++ b/src/tools/definitions.test.ts
@@ -71,11 +71,16 @@ describe('Tools Definitions', () => {
       const remindersProps = remindersTool?.inputSchema.properties ?? {};
 
       // Reminder write fields still wired through `event reminders create|update`
+      // (`startDate` is shared with the read-window filter below).
       expect(remindersProps).toHaveProperty('startDate');
       expect(remindersProps).toHaveProperty('dueDate');
       expect(remindersProps).toHaveProperty('priority');
       expect(remindersProps).toHaveProperty('tags');
       expect(remindersProps).toHaveProperty('subtasks');
+
+      // Reminder read filters: a due-date window is passed to the CLI.
+      expect(remindersProps).toHaveProperty('startDate');
+      expect(remindersProps).toHaveProperty('endDate');
 
       const calendarEventsTool = TOOLS.find(
         (tool) => tool.name === 'calendar_events',

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -92,12 +92,12 @@ export const TOOLS: Tool[] = [
         startDate: {
           type: 'string',
           description:
-            "Start date. When action='update': sets the reminder's start date (the CLI cannot set it at create time). When action='read': start of the due-date window, passed to the CLI as `--start` (start day inclusive). If only one of startDate/endDate is supplied for read, the other is filled in as a 14-day window. Format: 'YYYY-MM-DD', 'YYYY-MM-DD HH:mm:ss', or ISO 8601.",
+            "Start date. When action='update': sets the reminder's start date (the CLI cannot set it at create time) — format 'YYYY-MM-DD', 'YYYY-MM-DD HH:mm:ss', or ISO 8601. When action='read': start of the due-date window, passed to the CLI as `--start` (start day inclusive). For read, only the date part is used — any time/zone component is truncated to the date prefix, so a window is resolved at day granularity. If only one of startDate/endDate is supplied for read, the other is filled in as a 14-day window.",
         },
         endDate: {
           type: 'string',
           description:
-            "End of the due-date window (READ-only, action='read'). Passed to the CLI as `--end`; the end day is exclusive. If only one of startDate/endDate is supplied, the other is filled in as a 14-day window. Format: 'YYYY-MM-DD', 'YYYY-MM-DD HH:mm:ss', or ISO 8601.",
+            "End of the due-date window (READ-only, action='read'). Passed to the CLI as `--end`; the end day is exclusive. Only the date part is used — any time/zone component is truncated to the date prefix (day granularity). If only one of startDate/endDate is supplied, the other is filled in as a 14-day window.",
         },
         filterPriority: {
           type: 'string',

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -39,11 +39,6 @@ export const TOOLS: Tool[] = [
           description:
             'The title of the reminder (REQUIRED for create, optional for update).',
         },
-        startDate: {
-          type: 'string',
-          description:
-            "Start date. UPDATE-ONLY: the underlying CLI cannot set a start date at create time. RECOMMENDED format: 'YYYY-MM-DD HH:mm:ss' (local time without timezone). Also supports 'YYYY-MM-DD' and ISO 8601 with timezone.",
-        },
         dueDate: {
           type: 'string',
           description:
@@ -93,6 +88,16 @@ export const TOOLS: Tool[] = [
           enum: DUE_WITHIN_OPTIONS,
           description:
             'Filter reminders by a due date range (applied in TS after fetch).',
+        },
+        startDate: {
+          type: 'string',
+          description:
+            "Start date. When action='update': sets the reminder's start date (the CLI cannot set it at create time). When action='read': start of the due-date window, passed to the CLI as `--start` (start day inclusive). If only one of startDate/endDate is supplied for read, the other is filled in as a 14-day window. Format: 'YYYY-MM-DD', 'YYYY-MM-DD HH:mm:ss', or ISO 8601.",
+        },
+        endDate: {
+          type: 'string',
+          description:
+            "End of the due-date window (READ-only, action='read'). Passed to the CLI as `--end`; the end day is exclusive. If only one of startDate/endDate is supplied, the other is filled in as a 14-day window. Format: 'YYYY-MM-DD', 'YYYY-MM-DD HH:mm:ss', or ISO 8601.",
         },
         filterPriority: {
           type: 'string',

--- a/src/tools/handlers/reminderHandlers.ts
+++ b/src/tools/handlers/reminderHandlers.ts
@@ -298,6 +298,8 @@ export const handleReadReminders = async (
       recurring: validatedArgs.filterRecurring,
       locationBased: validatedArgs.filterLocationBased,
       tags: validatedArgs.filterTags,
+      startDate: validatedArgs.startDate,
+      endDate: validatedArgs.endDate,
     });
 
     return formatListMarkdown(

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -272,7 +272,9 @@ export interface RemindersToolArgs extends BaseToolArgs {
   // Write fields
   title?: string;
   newTitle?: string;
-  startDate?: string; // update only
+  // Read-only: start of the due-date window (action='read'); update: set the
+  // start date on an existing reminder (the CLI cannot set it at create time).
+  startDate?: string;
   dueDate?: string;
   note?: string;
   url?: string;
@@ -284,6 +286,7 @@ export interface RemindersToolArgs extends BaseToolArgs {
   removeTags?: string[];
   subtasks?: string[];
   targetList?: string;
+  endDate?: string; // read only: due-date window end
 }
 
 /**

--- a/src/types/repository.ts
+++ b/src/types/repository.ts
@@ -189,6 +189,8 @@ export interface IReminderRepository {
     recurring?: boolean;
     locationBased?: boolean;
     tags?: string[];
+    startDate?: string;
+    endDate?: string;
   }): Promise<Reminder[]>;
   findAllLists(): Promise<ReminderList[]>;
   createReminder(data: CreateReminderData): Promise<ReminderJSON>;

--- a/src/utils/calendarRepository.ts
+++ b/src/utils/calendarRepository.ts
@@ -15,6 +15,7 @@ import type {
   ICalendarRepository,
   UpdateEventData,
 } from '../types/repository.js';
+import { formatDateOnly, shiftDays, toDateOnly } from './dateUtils.js';
 import { CliUserError } from './errorHandling.js';
 import { executeEventCliJson, executeEventCliPlain } from './eventCli.js';
 import { addOptionalArg, nullToUndefined } from './helpers.js';
@@ -30,26 +31,6 @@ const DEFAULT_READ_WINDOW_DAYS = 14;
  * roughly that to stay within Apple's limits.
  */
 const FIND_BY_ID_WINDOW_DAYS = 365 * 4;
-
-const formatDateOnly = (date: Date): string => {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  return `${year}-${month}-${day}`;
-};
-
-const shiftDays = (date: Date, days: number): Date => {
-  const shifted = new Date(date);
-  shifted.setDate(shifted.getDate() + days);
-  return shifted;
-};
-
-// `event calendar list --start/--end` expects bare `yyyy-MM-dd`; trim any
-// time component from caller-supplied dates so the predicate succeeds.
-const toDateOnly = (value: string): string => {
-  const match = value.match(/^(\d{4}-\d{2}-\d{2})/);
-  return match?.[1] ?? value;
-};
 
 const resolveReadDateRange = (filters: {
   startDate?: string;

--- a/src/utils/dateFiltering.ts
+++ b/src/utils/dateFiltering.ts
@@ -124,6 +124,13 @@ export interface ReminderFilters {
   recurring?: boolean;
   locationBased?: boolean;
   tags?: string[];
+  /**
+   * Due-date window bounds passed straight to `event reminders list
+   * --start/--end`. Unlike `dueWithin` (which is applied in TS against a full
+   * fetch), a window is pushed down to the CLI so the fetch itself is scoped.
+   */
+  startDate?: string;
+  endDate?: string;
 }
 
 /**

--- a/src/utils/dateUtils.test.ts
+++ b/src/utils/dateUtils.test.ts
@@ -3,7 +3,12 @@
  * Tests for date calculation utilities
  */
 
-import { getWeekStart } from './dateUtils.js';
+import {
+  formatDateOnly,
+  getWeekStart,
+  shiftDays,
+  toDateOnly,
+} from './dateUtils.js';
 
 describe('getWeekStart', () => {
   // Wednesday, January 17, 2024 at noon
@@ -37,6 +42,44 @@ describe('getWeekStart', () => {
         (FIXED_DATE.getTime() - result.getTime()) / (1000 * 60 * 60 * 24);
       expect(daysDiff).toBeLessThan(7);
       expect(daysDiff).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe('formatDateOnly', () => {
+    it('formats a Date as a zero-padded yyyy-MM-dd string', () => {
+      expect(formatDateOnly(new Date(2026, 7, 4))).toBe('2026-08-04');
+      expect(formatDateOnly(new Date(2026, 0, 9))).toBe('2026-01-09');
+    });
+  });
+
+  describe('shiftDays', () => {
+    it('returns a new Date shifted by days without mutating the input', () => {
+      const date = new Date(2026, 7, 4);
+      const shifted = shiftDays(date, 14);
+      expect(shifted).toEqual(new Date(2026, 7, 18));
+      expect(shifted).not.toBe(date);
+      expect(date).toEqual(new Date(2026, 7, 4));
+    });
+
+    it('accepts a negative shift for past dates', () => {
+      expect(shiftDays(new Date(2026, 7, 24), -14)).toEqual(
+        new Date(2026, 7, 10),
+      );
+    });
+  });
+
+  describe('toDateOnly', () => {
+    it('trims a time component down to yyyy-MM-dd', () => {
+      expect(toDateOnly('2026-08-10 09:30:00')).toBe('2026-08-10');
+      expect(toDateOnly('2026-08-10T09:30:00Z')).toBe('2026-08-10');
+    });
+
+    it('passes a bare yyyy-MM-dd through unchanged', () => {
+      expect(toDateOnly('2026-08-10')).toBe('2026-08-10');
+    });
+
+    it('leaves non-matching input untouched (caller validation surfaces the error)', () => {
+      expect(toDateOnly('not-a-date')).toBe('not-a-date');
     });
   });
 });

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -76,3 +76,34 @@ export function getWeekEnd(): Date {
 export function getDateStart(date: Date): Date {
   return new Date(date.getFullYear(), date.getMonth(), date.getDate());
 }
+
+/**
+ * Formats a Date as a local `yyyy-MM-dd` string — the shape the `event` CLI
+ * accepts for `calendar list` / `reminders list` window bounds.
+ */
+export function formatDateOnly(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+/**
+ * Returns a new Date shifted by `days` (negative for the past), leaving the
+ * argument untouched.
+ */
+export function shiftDays(date: Date, days: number): Date {
+  const shifted = new Date(date);
+  shifted.setDate(shifted.getDate() + days);
+  return shifted;
+}
+
+/**
+ * Trims a caller-supplied date to a bare `yyyy-MM-dd` bound. The `event` CLI
+ * only accepts date-only window bounds, so any time component is dropped
+ * rather than passed through.
+ */
+export function toDateOnly(value: string): string {
+  const match = value.match(/^(\d{4}-\d{2}-\d{2})/);
+  return match?.[1] ?? value;
+}

--- a/src/utils/reminderDateParser.ts
+++ b/src/utils/reminderDateParser.ts
@@ -23,7 +23,11 @@ const createLocalDate = (
     return undefined;
   }
 
-  const date = new Date(year, month - 1, day, hour, minute, second, 0);
+  // `new Date(year, ...)` maps years 0-99 to 1900-1999, so the round-trip
+  // check would reject them. Seed from a far year, then `setFullYear` — which
+  // accepts 0-99 literally — so years below 100 parse correctly too.
+  const date = new Date(2000, month - 1, day, hour, minute, second, 0);
+  date.setFullYear(year);
 
   // Validate that the date wasn't auto-corrected by JavaScript
   if (

--- a/src/utils/reminderRepository.test.ts
+++ b/src/utils/reminderRepository.test.ts
@@ -235,6 +235,29 @@ describe('ReminderRepository (event CLI backend)', () => {
       ]);
     });
 
+    it('anchors a one-sided fill to the date prefix even when the time is a DST gap', async () => {
+      mockJson.mockResolvedValueOnce([]);
+
+      // A spring-forward time like 2026-03-08 02:30:00 is rejected by
+      // `parseReminderDueDate` (the hour normalizes away), but the truncated
+      // date prefix 2026-03-08 parses fine, so the filled end derives from
+      // March 8 (plus 14 days), not today.
+      await reminderRepository.findReminders({
+        startDate: '2026-03-08 02:30:00',
+      });
+
+      const call = mockJson.mock.calls[0]?.[0] as string[];
+      expect(call).toEqual([
+        'reminders',
+        'list',
+        '--start',
+        '2026-03-08',
+        '--end',
+        '2026-03-22',
+        '--json',
+      ]);
+    });
+
     it('pre-filters raw JSON for the structural filters (priority/recurring/locationBased) before mapReminder', async () => {
       mockJson.mockResolvedValueOnce([reminderFixture()]);
       const filters = {

--- a/src/utils/reminderRepository.test.ts
+++ b/src/utils/reminderRepository.test.ts
@@ -135,6 +135,106 @@ describe('ReminderRepository (event CLI backend)', () => {
       ]);
     });
 
+    it('passes --start/--end to the CLI when a full window is supplied', async () => {
+      mockJson.mockResolvedValueOnce([]);
+
+      await reminderRepository.findReminders({
+        startDate: '2026-08-10',
+        endDate: '2026-08-24',
+      });
+
+      expect(mockJson).toHaveBeenCalledWith([
+        'reminders',
+        'list',
+        '--start',
+        '2026-08-10',
+        '--end',
+        '2026-08-24',
+        '--json',
+      ]);
+    });
+
+    it('trims time components off window bounds before passing to the CLI', async () => {
+      mockJson.mockResolvedValueOnce([]);
+
+      await reminderRepository.findReminders({
+        startDate: '2026-08-10 09:30:00',
+        endDate: '2026-08-24 18:00:00',
+      });
+
+      expect(mockJson).toHaveBeenCalledWith([
+        'reminders',
+        'list',
+        '--start',
+        '2026-08-10',
+        '--end',
+        '2026-08-24',
+        '--json',
+      ]);
+    });
+
+    it('fills a missing end from a 14-day window when only startDate is given', async () => {
+      mockJson.mockResolvedValueOnce([]);
+
+      await reminderRepository.findReminders({ startDate: '2026-08-10' });
+
+      // Start is passed through untouched; the end is today+14 as date-only.
+      const call = mockJson.mock.calls[0]?.[0] as string[];
+      expect(call).toEqual([
+        'reminders',
+        'list',
+        '--start',
+        '2026-08-10',
+        '--end',
+        expect.any(String),
+        '--json',
+      ]);
+      const endDate = call[call.length - 2];
+      expect(endDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    });
+
+    it('fills a missing start from a 14-day window when only endDate is given', async () => {
+      mockJson.mockResolvedValueOnce([]);
+
+      await reminderRepository.findReminders({ endDate: '2026-08-24' });
+
+      // End is passed through untouched; the start is end-14 as date-only.
+      const call = mockJson.mock.calls[0]?.[0] as string[];
+      expect(call).toEqual([
+        'reminders',
+        'list',
+        '--start',
+        expect.any(String),
+        '--end',
+        '2026-08-24',
+        '--json',
+      ]);
+      const startDate = call[call.length - 4];
+      expect(startDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      expect(startDate).not.toBe('2026-08-24');
+    });
+
+    it('falls back to today when an unparseable bound is used to size the window', async () => {
+      mockJson.mockResolvedValueOnce([]);
+
+      // `parseReminderDueDate` rejects this string, so the window is sized from
+      // `new Date()`; the passed-through bound is still forwarded untouched.
+      await reminderRepository.findReminders({
+        startDate: 'not-a-real-date',
+      });
+
+      const call = mockJson.mock.calls[0]?.[0] as string[];
+      expect(call).toEqual([
+        'reminders',
+        'list',
+        '--start',
+        'not-a-real-date',
+        '--end',
+        expect.any(String),
+        '--json',
+      ]);
+    });
+
     it('pre-filters raw JSON for the structural filters (priority/recurring/locationBased) before mapReminder', async () => {
       mockJson.mockResolvedValueOnce([reminderFixture()]);
       const filters = {

--- a/src/utils/reminderRepository.ts
+++ b/src/utils/reminderRepository.ts
@@ -106,8 +106,10 @@ const resolveReadDateWindow = (filters: {
   if (filters.startDate && !filters.endDate) {
     // `parseReminderDueDate` is the strict parser shared with the calendar
     // pipeline; it rejects auto-corrected dates like `2025-02-30` that the
-    // native `Date` constructor silently coerces to March 2.
-    const start = parseReminderDueDate(filters.startDate);
+    // native `Date` constructor silently coerces to March 2. Parse the
+    // date-prefix so a DST-gap time (e.g. 2026-03-08 02:30:00 in a spring-forward
+    // zone) still anchors the fill to the supplied date instead of today.
+    const start = parseReminderDueDate(toDateOnly(filters.startDate));
     return {
       startDate: toDateOnly(filters.startDate),
       endDate: formatDateOnly(
@@ -118,7 +120,7 @@ const resolveReadDateWindow = (filters: {
 
   // !filters.startDate && filters.endDate
   const endStr = filters.endDate as string;
-  const end = parseReminderDueDate(endStr);
+  const end = parseReminderDueDate(toDateOnly(endStr));
   return {
     startDate: formatDateOnly(
       shiftDays(end ?? new Date(), -DEFAULT_READ_WINDOW_DAYS),

--- a/src/utils/reminderRepository.ts
+++ b/src/utils/reminderRepository.ts
@@ -22,6 +22,7 @@ import {
   applyReminderFilters,
   prefilterReminderJsons,
 } from './dateFiltering.js';
+import { formatDateOnly, shiftDays, toDateOnly } from './dateUtils.js';
 import { CliUserError } from './errorHandling.js';
 import { executeEventCliJson, executeEventCliPlain } from './eventCli.js';
 import {
@@ -29,6 +30,7 @@ import {
   addOptionalNumberArg,
   nullToUndefined,
 } from './helpers.js';
+import { parseReminderDueDate } from './reminderDateParser.js';
 import { getSubtaskProgress, parseSubtasks } from './subtaskUtils.js';
 import { extractTags } from './tagUtils.js';
 
@@ -75,6 +77,55 @@ const mapList = (list: ListJSON): ReminderList => ({
   title: list.title,
   color: list.color ?? undefined,
 });
+
+const DEFAULT_READ_WINDOW_DAYS = 14;
+
+/**
+ * Resolves the optional `--start/--end` window bounds the CLI expects. Both
+ * bounds are required by `event reminders list`, so a caller-supplied window
+ * is normalized to date-only strings and filled from the other side (a 14-day
+ * window) when only one bound is given. When neither is supplied, no window is
+ * applied — the CLI returns the full (incomplete) store, preserving the
+ * current default behavior.
+ */
+const resolveReadDateWindow = (filters: {
+  startDate?: string;
+  endDate?: string;
+}): { startDate?: string; endDate?: string } => {
+  if (!filters.startDate && !filters.endDate) {
+    return {};
+  }
+
+  if (filters.startDate && filters.endDate) {
+    return {
+      startDate: toDateOnly(filters.startDate),
+      endDate: toDateOnly(filters.endDate),
+    };
+  }
+
+  if (filters.startDate && !filters.endDate) {
+    // `parseReminderDueDate` is the strict parser shared with the calendar
+    // pipeline; it rejects auto-corrected dates like `2025-02-30` that the
+    // native `Date` constructor silently coerces to March 2.
+    const start = parseReminderDueDate(filters.startDate);
+    return {
+      startDate: toDateOnly(filters.startDate),
+      endDate: formatDateOnly(
+        shiftDays(start ?? new Date(), DEFAULT_READ_WINDOW_DAYS),
+      ),
+    };
+  }
+
+  // !filters.startDate && filters.endDate
+  const endStr = filters.endDate as string;
+  const end = parseReminderDueDate(endStr);
+  return {
+    startDate: formatDateOnly(
+      shiftDays(end ?? new Date(), -DEFAULT_READ_WINDOW_DAYS),
+    ),
+    endDate: toDateOnly(endStr),
+  };
+};
 
 class ReminderRepository implements IReminderRepository {
   private mapReminder(reminder: ReminderJSON): Reminder {
@@ -191,6 +242,13 @@ class ReminderRepository implements IReminderRepository {
     addOptionalArg(args, '--list', filters.list);
     if (filters.showCompleted) {
       args.push('--completed');
+    }
+    const window = resolveReadDateWindow(filters);
+    if (window.startDate) {
+      args.push('--start', window.startDate);
+    }
+    if (window.endDate) {
+      args.push('--end', window.endDate);
     }
     args.push('--json');
 

--- a/src/validation/schemas.test.ts
+++ b/src/validation/schemas.test.ts
@@ -1097,6 +1097,29 @@ describe('ValidationSchemas', () => {
           }),
         ).not.toThrow();
       });
+
+      it('accepts a window whose bare date is interpreted in local time (no timezone mixing)', () => {
+        // Regression: the end<start comparison used to mix timezones — a bare
+        // `YYYY-MM-DD` bound was parsed as UTC midnight by `Date.parse` while a
+        // time-bearing bound was local, wrongly rejecting this valid window
+        // outside UTC. `parseReminderDueDate` treats the bare date as local
+        // midnight, matching how the CLI resolves the bounds.
+        expect(() =>
+          ReadRemindersSchema.parse({
+            startDate: '2026-08-10 23:30:00',
+            endDate: '2026-08-11',
+          }),
+        ).not.toThrow();
+      });
+
+      it('rejects a genuinely reversed window regardless of format mixing', () => {
+        expect(() =>
+          ReadRemindersSchema.parse({
+            startDate: '2026-08-11 09:00:00',
+            endDate: '2026-08-10',
+          }),
+        ).toThrow(/endDate must be on or after startDate/);
+      });
     });
 
     // UpdateReminderListSchema is covered by the alignment block above.

--- a/src/validation/schemas.test.ts
+++ b/src/validation/schemas.test.ts
@@ -1053,6 +1053,50 @@ describe('ValidationSchemas', () => {
         expect(() => ReadRemindersSchema.parse(validInput)).not.toThrow();
         expect(() => ReadRemindersSchema.parse({})).not.toThrow();
       });
+
+      it('accepts a due-date window', () => {
+        expect(() =>
+          ReadRemindersSchema.parse({
+            startDate: '2026-08-10',
+            endDate: '2026-08-24',
+          }),
+        ).not.toThrow();
+        expect(() =>
+          ReadRemindersSchema.parse({
+            startDate: '2026-08-10 09:00:00',
+            endDate: '2026-08-24 18:00:00',
+          }),
+        ).not.toThrow();
+      });
+
+      it('rejects a malformed window bound', () => {
+        expect(() =>
+          ReadRemindersSchema.parse({
+            startDate: 'not-a-date',
+            endDate: '2026-08-24',
+          }),
+        ).toThrow(/Date/);
+      });
+
+      it('rejects a reversed window (endDate before startDate)', () => {
+        expect(() =>
+          ReadRemindersSchema.parse({
+            startDate: '2026-08-24',
+            endDate: '2026-08-10',
+          }),
+        ).toThrow(/endDate must be on or after startDate/);
+      });
+
+      it('accepts a single-day window (startDate equal to endDate)', () => {
+        // The end day is exclusive, so this returns zero reminders, but it is
+        // a valid window — no validation error.
+        expect(() =>
+          ReadRemindersSchema.parse({
+            startDate: '2026-08-10',
+            endDate: '2026-08-10',
+          }),
+        ).not.toThrow();
+      });
     });
 
     // UpdateReminderListSchema is covered by the alignment block above.

--- a/src/validation/schemas.test.ts
+++ b/src/validation/schemas.test.ts
@@ -1120,6 +1120,19 @@ describe('ValidationSchemas', () => {
           }),
         ).toThrow(/endDate must be on or after startDate/);
       });
+
+      it('rejects a reversed window with years 0000-0099 (parsed correctly via setFullYear)', () => {
+        // Regression: `createLocalDate` used `new Date(year, ...)` which maps
+        // years 0-99 to 1900-1999, so `parseReminderDueDate` returned undefined
+        // and the reversed-window guard silently skipped these inputs. Now the
+        // reversed window is properly rejected.
+        expect(() =>
+          ReadRemindersSchema.parse({
+            startDate: '0099-01-01',
+            endDate: '0098-01-01',
+          }),
+        ).toThrow(/endDate must be on or after startDate/);
+      });
     });
 
     // UpdateReminderListSchema is covered by the alignment block above.

--- a/src/validation/schemas.ts
+++ b/src/validation/schemas.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod/v3';
 import { VALIDATION } from '../utils/constants.js';
+import { parseReminderDueDate } from '../utils/reminderDateParser.js';
 
 // Security patterns – allow printable Unicode text while blocking dangerous control and delimiter chars.
 // Allows standard printable ASCII, extended Latin, CJK, plus newlines/tabs for notes.
@@ -497,17 +498,13 @@ export const ReadRemindersSchema = z
   })
   .superRefine((value, ctx) => {
     if (!value.startDate || !value.endDate) return;
-    const start = Date.parse(
-      value.startDate.includes(' ')
-        ? value.startDate.replace(' ', 'T')
-        : value.startDate,
-    );
-    const end = Date.parse(
-      value.endDate.includes(' ')
-        ? value.endDate.replace(' ', 'T')
-        : value.endDate,
-    );
-    if (Number.isNaN(start) || Number.isNaN(end)) return; // shape errors surface elsewhere
+    // `parseReminderDueDate` interprets a bare `YYYY-MM-DD` as local midnight,
+    // matching how the window bounds are resolved downstream. `Date.parse`
+    // would treat a bare date as UTC midnight while a time-bearing bound is
+    // local, mixing timezones and wrongly rejecting valid windows off-UTC.
+    const start = parseReminderDueDate(value.startDate)?.getTime();
+    const end = parseReminderDueDate(value.endDate)?.getTime();
+    if (start === undefined || end === undefined) return; // shape errors surface elsewhere
     if (end < start) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
@@ -596,17 +593,13 @@ export const ReadCalendarsSchema = z
   })
   .superRefine((value, ctx) => {
     if (!value.startDate || !value.endDate) return;
-    const start = Date.parse(
-      value.startDate.includes(' ')
-        ? value.startDate.replace(' ', 'T')
-        : value.startDate,
-    );
-    const end = Date.parse(
-      value.endDate.includes(' ')
-        ? value.endDate.replace(' ', 'T')
-        : value.endDate,
-    );
-    if (Number.isNaN(start) || Number.isNaN(end)) return; // shape errors surface elsewhere
+    // `parseReminderDueDate` interprets a bare `YYYY-MM-DD` as local midnight,
+    // matching how the window bounds are resolved downstream. `Date.parse`
+    // would treat a bare date as UTC midnight while a time-bearing bound is
+    // local, mixing timezones and wrongly rejecting valid windows off-UTC.
+    const start = parseReminderDueDate(value.startDate)?.getTime();
+    const end = parseReminderDueDate(value.endDate)?.getTime();
+    if (start === undefined || end === undefined) return; // shape errors surface elsewhere
     if (end < start) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,

--- a/src/validation/schemas.ts
+++ b/src/validation/schemas.ts
@@ -481,17 +481,41 @@ export const SafeIdSchema = z.string().min(1, 'ID cannot be empty');
  */
 export const CreateReminderSchema = z.object(BaseReminderFields);
 
-export const ReadRemindersSchema = z.object({
-  id: SafeIdSchema.optional(),
-  filterList: SafeListNameSchema,
-  showCompleted: z.boolean().optional().default(false),
-  search: SafeSearchSchema,
-  dueWithin: DueWithinEnum,
-  filterPriority: PriorityFilterEnum,
-  filterRecurring: z.boolean().optional(),
-  filterLocationBased: z.boolean().optional(),
-  filterTags: TagArraySchema,
-});
+export const ReadRemindersSchema = z
+  .object({
+    id: SafeIdSchema.optional(),
+    filterList: SafeListNameSchema,
+    showCompleted: z.boolean().optional().default(false),
+    search: SafeSearchSchema,
+    dueWithin: DueWithinEnum,
+    filterPriority: PriorityFilterEnum,
+    filterRecurring: z.boolean().optional(),
+    filterLocationBased: z.boolean().optional(),
+    filterTags: TagArraySchema,
+    startDate: SafeDateSchema,
+    endDate: SafeDateSchema,
+  })
+  .superRefine((value, ctx) => {
+    if (!value.startDate || !value.endDate) return;
+    const start = Date.parse(
+      value.startDate.includes(' ')
+        ? value.startDate.replace(' ', 'T')
+        : value.startDate,
+    );
+    const end = Date.parse(
+      value.endDate.includes(' ')
+        ? value.endDate.replace(' ', 'T')
+        : value.endDate,
+    );
+    if (Number.isNaN(start) || Number.isNaN(end)) return; // shape errors surface elsewhere
+    if (end < start) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['endDate'],
+        message: 'endDate must be on or after startDate',
+      });
+    }
+  });
 
 /** Fields accepted by `event reminders update`. */
 export const UpdateReminderSchema = z.object({


### PR DESCRIPTION
## Summary

Adds `startDate` / `endDate` read filters to the `reminders_tasks` tool so MCP clients can query reminders by a due-date window, matching the existing `calendar_events` behavior.

## Changes

- **`ReadRemindersSchema`**: accepts `startDate` / `endDate`; rejects a reversed window (`endDate < startDate`) via `superRefine`, mirroring `ReadCalendarsSchema`.
- **`reminderRepository.findReminders`**: resolves the window and passes `--start`/`--end` to `event reminders list`; one-sided windows are filled to a 14-day window; no window → full (incomplete) store (default preserved).
- **Tool definitions / types / handler**: `startDate`/`endDate` wired through `reminders_tasks`, `RemindersToolArgs`, `ReminderFilters`, and `handleReadReminders`.
- **Date utils**: shared `formatDateOnly`/`shiftDays`/`toDateOnly` extracted to `dateUtils.ts` and reused by the calendar repository (dedup).
- **Tests + README**: repository/schema/definitions/dateUtils tests; README example + capabilities note.

## Related Issues

None linked.

## Cross-repo dependency

This PR's submodule pointer moves `vendor/event` to commit `75b9b5f`, which is the head of **PR FradSer/event#16** ("feat(app): support due-date window in reminders list") — the event CLI commit that adds `--start`/`--end`. The TS code calls those flags, so **event#16 must merge first** (or together). The MCP tests pass regardless (the CLI is mocked), but the real integration needs the event CLI change.

## Testing

- [x] Unit tests added/updated
- [x] All tests pass (659 MCP server tests)
- [x] Manual testing completed (CLI `--start/--end` verified against real EventKit data)

## Checklist

- [x] No sensitive data exposed
- [x] Linting and type checking passed
- [x] Documentation updated (README)
- [x] Breaking changes documented (new read-only window args; `startDate` now dual-purpose read/update)