### PR TITLE
fix: unblock npm release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,8 +32,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10.28.2
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/features/npm-release.feature
+++ b/features/npm-release.feature
@@ -1,0 +1,9 @@
+Feature: Publish the documented package version to npm
+  The npm release workflow must be able to publish tagged releases so users of
+  npx mcp-server-apple-events receive the version documented by the repository.
+
+  Scenario: Install the package manager version declared by the project
+    Given the package declares its package manager and version
+    When the release workflow sets up pnpm
+    Then the workflow does not declare a conflicting pnpm version
+    And pnpm action setup can use the package manager declaration

--- a/src/__tests__/package-release.test.ts
+++ b/src/__tests__/package-release.test.ts
@@ -52,4 +52,13 @@ describe('release package contents', () => {
     expect(releaseWorkflow).toMatch(/Authority=Developer ID Application:/);
     expect(releaseWorkflow).toMatch(/codesign --verify --strict/);
   });
+
+  it('uses the package manager version declared by package.json', () => {
+    expect(packageJson.packageManager).toMatch(/^pnpm@\d+\.\d+\.\d+/);
+    const pnpmSetup = releaseWorkflow.match(
+      /- name: Setup pnpm[\s\S]*?(?=\n\s+- name:)/,
+    )?.[0];
+    expect(pnpmSetup).toMatch(/uses: pnpm\/action-setup@v4/);
+    expect(pnpmSetup).not.toMatch(/version:/);
+  });
 });


### PR DESCRIPTION
## What

- Remove the conflicting explicit pnpm version from the release workflow.
- Let `pnpm/action-setup@v4` resolve the exact version, including the Corepack hash, from `package.json`.
- Add BDD and Jest regression coverage for the release setup.

## Why

The v1.5.0 release workflow failed before installation because `pnpm/action-setup@v4` received both a plain `version` input and the repository's `packageManager` declaration. This prevented the documented package version from being published to npm.

## Verification

- `pnpm test -- src/__tests__/package-release.test.ts --runInBand`
- `pnpm exec tsc --noEmit --project tsconfig.json`
- `pnpm exec biome check src/__tests__/package-release.test.ts`
- `git diff --check`

Full test execution still has unrelated environment/build-artifact failures in the existing E2E and published-tarball suites; 625 other tests passed.

Closes #118
