### PR TITLE
ci: enable npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,14 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Publish the existing v1.5.0 tag
+        required: true
+        type: choice
+        options:
+          - v1.5.0
 
 # Serialize release runs so rapid tag pushes don't race on `npm publish`.
 concurrency:
@@ -18,8 +26,8 @@ jobs:
     # rotates runner images. Bumping is intentional.
     runs-on: macos-14
 
-    # id-token: write is required for `npm publish --provenance`, which binds
-    # the published tarball to this workflow run via Sigstore.
+    # npm trusted publishing exchanges this job's OIDC identity for a
+    # short-lived npm publish token; no long-lived npm secret is required.
     permissions:
       contents: read
       id-token: write
@@ -28,6 +36,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.tag || github.ref }}
           submodules: recursive
 
       - name: Setup pnpm
@@ -36,12 +45,17 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'pnpm'
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Verify npm trusted publishing client
+        run: |
+          set -euo pipefail
+          npm install --global npm@11.5.1
+          npm --version
 
       - name: Import Developer ID Application certificate
         env:
@@ -130,9 +144,7 @@ jobs:
         run: pnpm test
 
       - name: Publish to npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access public --provenance
+        run: npm publish --access public
 
       - name: Restore default keychain and clean up
         if: always()

--- a/features/npm-release.feature
+++ b/features/npm-release.feature
@@ -7,3 +7,15 @@ Feature: Publish the documented package version to npm
     When the release workflow sets up pnpm
     Then the workflow does not declare a conflicting pnpm version
     And pnpm action setup can use the package manager declaration
+
+  Scenario: Publish through npm trusted publishing
+    Given npm has a trusted publisher configured for FradSer/mcp-server-apple-events and release.yml
+    When the release workflow publishes a tagged release
+    Then the job grants GitHub's OIDC token permission
+    And the job uses Node.js 24 and npm 11.5.1 or newer
+    And npm publish does not use a long-lived npm token
+
+  Scenario: Recover the existing v1.5.0 tag
+    Given the v1.5.0 tag exists but was created before this workflow merged
+    When the release workflow is dispatched manually
+    Then the only selectable recovery tag is v1.5.0

--- a/src/__tests__/package-release.test.ts
+++ b/src/__tests__/package-release.test.ts
@@ -61,4 +61,25 @@ describe('release package contents', () => {
     expect(pnpmSetup).toMatch(/uses: pnpm\/action-setup@v4/);
     expect(pnpmSetup).not.toMatch(/version:/);
   });
+
+  it('uses npm trusted publishing requirements', () => {
+    expect(releaseWorkflow).toMatch(/id-token:\s*write/);
+    expect(releaseWorkflow).toMatch(/node-version:\s*['"]24['"]/);
+    expect(releaseWorkflow).toMatch(
+      /npm publish --access public(?![^\n]*--provenance)/,
+    );
+    expect(releaseWorkflow).not.toMatch(
+      /NPM_TOKEN|NODE_AUTH_TOKEN|provenance-token/,
+    );
+    expect(releaseWorkflow).toMatch(/npm --version/);
+    expect(releaseWorkflow).toMatch(/11\.5\.1/);
+  });
+
+  it('limits manual recovery publishing to v1.5.0', () => {
+    expect(releaseWorkflow).toMatch(/workflow_dispatch:/);
+    expect(releaseWorkflow).toMatch(/description:.*v1\.5\.0/);
+    expect(releaseWorkflow).toMatch(/type:\s*choice/);
+    expect(releaseWorkflow).toMatch(/options:\s*\n\s+- v1\.5\.0/);
+    expect(releaseWorkflow).toMatch(/ref:.*inputs\.tag \|\| github\.ref/);
+  });
 });


### PR DESCRIPTION
## What

- Configure npm Trusted Publishing with GitHub Actions OIDC.
- Upgrade the release runner to Node.js 24 and npm 11.5.1+.
- Remove long-lived npm token authentication.
- Add a narrowly scoped manual recovery dispatch for the existing `v1.5.0` tag.

## Why

The existing `v1.5.0` tag predates the fixed release workflow and its run failed during pnpm setup. npm's current recommended publishing flow uses Trusted Publishing instead of long-lived npm tokens. The macOS runner and signing/notarization steps remain unchanged because the package ships a signed universal Swift binary.

Before publishing, configure npm Trusted Publisher for:

- Owner: `FradSer`
- Repository: `mcp-server-apple-events`
- Workflow filename: `release.yml`
- Allowed action: `npm publish`

## Verification

- `pnpm test -- src/__tests__/package-release.test.ts --runInBand` (9 passed)
- `pnpm exec tsc --noEmit --project tsconfig.json`
- `pnpm exec biome check src/__tests__/package-release.test.ts`
- `git diff --check`

The manual recovery input only permits `v1.5.0`; normal tag pushes continue to use the pushed tag ref.
