### PR TITLE
ci: skip gui tests during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,8 +136,10 @@ jobs:
             }
           '
 
-      - name: Run tests
-        run: pnpm test
+      - name: Run release tests
+        # EventKit E2E calls require a user GUI and Reminders/Calendar
+        # permissions, which are unavailable on GitHub-hosted runners.
+        run: pnpm test -- --runInBand --testPathIgnorePatterns=src/e2e.test.ts
 
       - name: Publish to npm
         run: npm publish --access public

--- a/src/__tests__/package-release.test.ts
+++ b/src/__tests__/package-release.test.ts
@@ -63,6 +63,9 @@ describe('release package contents', () => {
     expect(releaseWorkflow).toMatch(
       /pnpm install --frozen-lockfile --ignore-scripts/,
     );
+    expect(releaseWorkflow).toMatch(
+      /pnpm test -- --runInBand --testPathIgnorePatterns=src\/e2e\.test\.ts/,
+    );
   });
 
   it('pins the CI runner image and verifies the ad-hoc signed universal binary', () => {


### PR DESCRIPTION
## What

- Exclude the EventKit E2E suite from release CI.
- Keep unit, package-content, build, binary, and npm publishing checks enabled.

## Why

The release runner is a GitHub-hosted macOS machine without the user's GUI session or Reminders/Calendar permissions. The EventKit E2E tests therefore time out even though the package build and release validation succeed. Release CI should validate publishable artifacts without requiring local user permissions.

## Verification

- Targeted package-release tests: 9 passed
- TypeScript typecheck: passed
- Biome: passed
- `git diff --check`: passed

This continues the upstream `event` release-asset packaging and npm Trusted Publishing workflow from the previous release PR.
