### PR TITLE
fix: invoke jest correctly in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,7 +139,7 @@ jobs:
       - name: Run release tests
         # EventKit E2E calls require a user GUI and Reminders/Calendar
         # permissions, which are unavailable on GitHub-hosted runners.
-        run: pnpm test -- --runInBand --testPathIgnorePatterns=src/e2e.test.ts
+        run: pnpm exec jest --runInBand --testPathIgnorePatterns=src/e2e.test.ts
 
       - name: Publish to npm
         run: npm publish --access public

--- a/src/__tests__/package-release.test.ts
+++ b/src/__tests__/package-release.test.ts
@@ -64,7 +64,7 @@ describe('release package contents', () => {
       /pnpm install --frozen-lockfile --ignore-scripts/,
     );
     expect(releaseWorkflow).toMatch(
-      /pnpm test -- --runInBand --testPathIgnorePatterns=src\/e2e\.test\.ts/,
+      /pnpm exec jest --runInBand --testPathIgnorePatterns=src\/e2e\.test\.ts/,
     );
   });
 


### PR DESCRIPTION
## What

- Run Jest directly in release CI so `--runInBand` and the EventKit E2E exclusion are parsed as options.
- Update the release workflow regression assertion.

## Why

The previous command used `pnpm test -- ...`; this project's `test` script forwards the arguments into Jest as a positional pattern, causing Jest to find no tests. The release job therefore stopped before npm publishing despite the artifact checks passing.

## Verification

- Targeted package-release tests: 9 passed
- TypeScript typecheck: passed
- Biome: passed
- `git diff --check`: passed

Closes #118
