### PR TITLE
fix: align npm repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "homepage": "https://frad.me",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/fradser/mcp-server-apple-events.git"
+    "url": "git+https://github.com/FradSer/mcp-server-apple-events.git"
   },
   "bugs": {
     "url": "https://github.com/fradser/mcp-server-apple-events/issues"

--- a/src/__tests__/package-release.test.ts
+++ b/src/__tests__/package-release.test.ts
@@ -84,6 +84,9 @@ describe('release package contents', () => {
   });
 
   it('uses npm trusted publishing requirements', () => {
+    expect(packageJson.repository.url).toBe(
+      'git+https://github.com/FradSer/mcp-server-apple-events.git',
+    );
     expect(releaseWorkflow).toMatch(/id-token:\s*write/);
     expect(releaseWorkflow).toMatch(/node-version:\s*['"]24['"]/);
     expect(releaseWorkflow).toMatch(


### PR DESCRIPTION
## What

- Update `package.json.repository.url` to the canonical `FradSer` owner casing.
- Assert the exact repository metadata used by npm Trusted Publishing.

## Why

npm Trusted Publishing requires the package repository URL to match the GitHub repository exactly. The latest `main` still used lowercase `fradser`, while the Trusted Publisher is configured for `FradSer/mcp-server-apple-events`.

The branch was rebased onto the latest `main` before this change.

## Verification

- `pnpm test -- src/__tests__/package-release.test.ts --runInBand` (9 passed)
- `pnpm exec biome check src/__tests__/package-release.test.ts`
- `pnpm exec tsc --noEmit --project tsconfig.json`
- `git diff --check`
